### PR TITLE
[Glad] Step 7-1, 7-2 index.html & 다양한 컨텐츠 지원

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # be-was-2024
 코드스쿼드 백엔드 교육용 WAS 2024 개정판
+
+## 1. index.html 응답
+
+### static html file 응답
+
+- http://localhost:8080/index.html 접속시 src/main/resources/static/index.html 파일을 응답
+
+### HTTP Request 출력
+
+- HTTP Request를 콘솔에 출력
+- 적절하게 파싱 후 `log.debug()`로 출력
+
+### 구조 변경
+
+- `Thread` 기반 구조에서 `Concurrent` 기반 구조로 변경

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,12 @@ plugins {
     id 'java'
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
 group 'codesquad'
 version '1.0-SNAPSHOT'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -2,6 +2,7 @@ package webserver;
 
 import java.io.*;
 import java.net.Socket;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -39,7 +40,44 @@ public class RequestHandler implements Runnable {
             }
 
             String uri = tokens[1];
-            InputStream fileIn = getClass().getClassLoader().getResourceAsStream("static" + uri);
+            String resourcePath = "static" + uri;
+            InputStream fileIn = null;
+
+            // 먼저 URL을 통해 리소스 존재 여부 확인
+            var resourceUrl = getClass().getClassLoader().getResource(resourcePath);
+            if (resourceUrl != null) {
+                // 파일 시스템 프로토콜이면 실제 디렉토리인지 확인
+                if ("file".equals(resourceUrl.getProtocol())) {
+                    File file = new File(resourceUrl.toURI());
+                    if (file.isDirectory()) {
+                        // 디렉토리인 경우, 자동으로 index.html을 붙여서 다시 시도
+                        if (!uri.endsWith("/")) {
+                            uri += "/";
+                        }
+                        resourcePath = "static" + uri + "index.html";
+                        resourceUrl = getClass().getClassLoader().getResource(resourcePath);
+                        if (resourceUrl != null) {
+                            fileIn = resourceUrl.openStream();
+                            uri = uri + "index.html";
+                        }
+                    } else {
+                        fileIn = resourceUrl.openStream();
+                    }
+                } else {
+                    // URI가 "/"로 끝나면 index.html 시도
+                    if (uri.endsWith("/")) {
+                        resourcePath = "static" + uri + "index.html";
+                        resourceUrl = getClass().getClassLoader().getResource(resourcePath);
+                        if (resourceUrl != null) {
+                            fileIn = resourceUrl.openStream();
+                            uri = uri + "index.html";
+                        }
+                    } else {
+                        fileIn = resourceUrl.openStream();
+                    }
+                }
+            }
+
             if (fileIn != null) {
                 // 파일을 읽어 응답 본문에 담음
                 byte[] body = fileIn.readAllBytes();
@@ -55,6 +93,8 @@ public class RequestHandler implements Runnable {
             }
         } catch (IOException e) {
             logger.error(e.getMessage());
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.http.HttpRequest;
 import webserver.http.HttpResponse;
 
 public class RequestHandler implements Runnable {
@@ -28,20 +29,16 @@ public class RequestHandler implements Runnable {
             DataOutputStream dos = new DataOutputStream(out);
             HttpResponse response = new HttpResponse(dos);
 
-            Map<String, String> headers = parseRequestHeader(br);
-            String requestLine = headers.get("Request-Line");
-            if (requestLine == null || requestLine.isEmpty()) {
+            HttpRequest request;
+            try {
+                request = new HttpRequest(br);
+            } catch (IOException e) {
+                logger.error("Request parsing error: {}", e.getMessage());
                 response.send400();
                 return;
             }
 
-            String[] tokens = requestLine.split(" ");
-            if (tokens.length < 2) {
-                response.send400();
-                return;
-            }
-
-            String uri = tokens[1];
+            String uri = request.getUri();
             String resourcePath = "static" + uri;
             InputStream fileIn = null;
 
@@ -95,29 +92,6 @@ public class RequestHandler implements Runnable {
         } catch (URISyntaxException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private Map<String, String> parseRequestHeader(BufferedReader br) throws IOException {
-        Map<String, String> headers = new HashMap<>();
-
-        // 요청 라인(예: "GET / HTTP/1.1")을 읽고 저장
-        String requestLine = br.readLine();
-        headers.put("Request-Line", requestLine);
-        logger.debug(requestLine);
-
-        String line;
-        // 요청 헤더를 읽고 저장
-        while ((line = br.readLine()) != null && !line.isEmpty()) {
-            logger.debug(line);
-            int colonIndex = line.indexOf(":");
-            if (colonIndex != -1) {
-                String key = line.substring(0, colonIndex).trim();
-                String value = line.substring(colonIndex + 1).trim();
-                headers.put(key, value);
-            }
-        }
-
-        return headers;
     }
 
     private String getContentType(String uri) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -129,21 +129,29 @@ public class RequestHandler implements Runnable {
         }
     }
 
-    private void response404Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) throws IOException {
-        dos.writeBytes("HTTP/1.1 404 Not Found\r\n");
-        dos.writeBytes("Content-Type: " + contentType + "\r\n");
-        dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
-        dos.writeBytes("\r\n");
+    private void response404Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {
+        try {
+            dos.writeBytes("HTTP/1.1 404 Not Found\r\n");
+            dos.writeBytes("Content-Type: " + contentType + "\r\n");
+            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
+            dos.writeBytes("\r\n");
+        } catch (IOException e) {
+            logger.error(e.getMessage());
+        }
     }
 
-    private void send400Response(DataOutputStream dos) throws IOException {
+    private void send400Response(DataOutputStream dos) {
         String badRequestHtml = "<h1>400 Bad Request</h1>";
         byte[] badRequestBody = badRequestHtml.getBytes();
-        dos.writeBytes("HTTP/1.1 400 Bad Request\r\n");
-        dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
-        dos.writeBytes("Content-Length: " + badRequestBody.length + "\r\n");
-        dos.writeBytes("\r\n");
-        dos.write(badRequestBody);
-        dos.flush();
+        try {
+            dos.writeBytes("HTTP/1.1 400 Bad Request\r\n");
+            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Content-Length: " + badRequestBody.length + "\r\n");
+            dos.writeBytes("\r\n");
+            dos.write(badRequestBody);
+            dos.flush();
+        } catch (IOException e) {
+            logger.error(e.getMessage());
+        }
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,10 +1,9 @@
 package webserver;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.Socket;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,14 +22,40 @@ public class RequestHandler implements Runnable {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
-            // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
+            BufferedReader br = new BufferedReader(new InputStreamReader(in));
             DataOutputStream dos = new DataOutputStream(out);
+
+            Map<String, String> headers = parseRequestHeader(br);
+
             byte[] body = "<h1>Hello World</h1>".getBytes();
             response200Header(dos, body.length);
             responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
+    }
+
+    private Map<String, String> parseRequestHeader(BufferedReader br) throws IOException {
+        Map<String, String> headers = new HashMap<>();
+
+        // 요청 라인(예: "GET / HTTP/1.1")을 읽고 저장
+        String requestLine = br.readLine();
+        headers.put("Request-Line", requestLine);
+        logger.debug(requestLine);
+
+        String line;
+        // 요청 헤더를 읽고 저장
+        while ((line = br.readLine()) != null && !line.isEmpty()) {
+            logger.debug(line);
+            int colonIndex = line.indexOf(":");
+            if (colonIndex != -1) {
+                String key = line.substring(0, colonIndex).trim();
+                String value = line.substring(colonIndex + 1).trim();
+                headers.put(key, value);
+            }
+        }
+
+        return headers;
     }
 
     private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -2,18 +2,16 @@ package webserver;
 
 import java.io.*;
 import java.net.Socket;
-import java.net.URISyntaxException;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.resolver.ResourceResolver;
 import webserver.http.HttpRequest;
 import webserver.http.HttpResponse;
 
 public class RequestHandler implements Runnable {
-    private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
+    private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
     private final Socket connection;
 
     public RequestHandler(Socket connectionSocket) {
@@ -29,96 +27,11 @@ public class RequestHandler implements Runnable {
             DataOutputStream dos = new DataOutputStream(out);
             HttpResponse response = new HttpResponse(dos);
 
-            HttpRequest request;
-            try {
-                request = new HttpRequest(br);
-            } catch (IOException e) {
-                logger.error("Request parsing error: {}", e.getMessage());
-                response.send400();
-                return;
-            }
-
-            String uri = request.getUri();
-            String resourcePath = "static" + uri;
-            InputStream fileIn = null;
-
-            // 먼저 URL을 통해 리소스 존재 여부 확인
-            var resourceUrl = getClass().getClassLoader().getResource(resourcePath);
-            if (resourceUrl != null) {
-                // 파일 시스템 프로토콜이면 실제 디렉토리인지 확인
-                if ("file".equals(resourceUrl.getProtocol())) {
-                    File file = new File(resourceUrl.toURI());
-                    if (file.isDirectory()) {
-                        // 디렉토리인 경우, 자동으로 index.html을 붙여서 다시 시도
-                        if (!uri.endsWith("/")) {
-                            uri += "/";
-                        }
-                        resourcePath = "static" + uri + "index.html";
-                        resourceUrl = getClass().getClassLoader().getResource(resourcePath);
-                        if (resourceUrl != null) {
-                            fileIn = resourceUrl.openStream();
-                            uri = uri + "index.html";
-                        }
-                    } else {
-                        fileIn = resourceUrl.openStream();
-                    }
-                } else {
-                    // URI가 "/"로 끝나면 index.html 시도
-                    if (uri.endsWith("/")) {
-                        resourcePath = "static" + uri + "index.html";
-                        resourceUrl = getClass().getClassLoader().getResource(resourcePath);
-                        if (resourceUrl != null) {
-                            fileIn = resourceUrl.openStream();
-                            uri = uri + "index.html";
-                        }
-                    } else {
-                        fileIn = resourceUrl.openStream();
-                    }
-                }
-            }
-
-            if (fileIn != null) {
-                // 파일을 읽어 응답 본문에 담음
-                byte[] body = fileIn.readAllBytes();
-                String contentType = getContentType(uri);
-                response.sendResponse(200, "OK", contentType, body);
-
-            } else {
-                logger.error("File not found: static{}", uri);
-                response.send404();
-            }
+            HttpRequest request = new HttpRequest(br);
+            ResourceResolver resourceResolver = new ResourceResolver(request, response);
+            resourceResolver.resolve();
         } catch (IOException e) {
-            logger.error(e.getMessage());
-        } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private String getContentType(String uri) {
-        String lowerUri = uri.toLowerCase();
-
-        if (lowerUri.endsWith(".html") || lowerUri.endsWith(".htm")) {
-            return "text/html;charset=utf-8";
-        } else if (lowerUri.endsWith(".css")) {
-            return "text/css;charset=utf-8";
-        } else if (lowerUri.endsWith(".js")) {
-            return "application/javascript;charset=utf-8";
-        } else if (lowerUri.endsWith(".png")) {
-            return "image/png";
-        } else if (lowerUri.endsWith(".svg")) {
-            return "image/svg+xml";
-        } else if (lowerUri.endsWith(".ico")) {
-            return "image/x-icon";
-        } else if (lowerUri.endsWith(".jpg") || lowerUri.endsWith(".jpeg")) {
-            return "image/jpeg";
-        } else if (lowerUri.endsWith(".gif")) {
-            return "image/gif";
-        } else if (lowerUri.endsWith(".json")) {
-            return "application/json;charset=utf-8";
-        } else if (lowerUri.endsWith(".xml")) {
-            return "application/xml;charset=utf-8";
-        } else {
-            return "application/octet-stream";
+            logger.error("Error initializing streams: {}", e.getMessage());
         }
     }
 

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.http.HttpResponse;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
@@ -25,17 +26,18 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             BufferedReader br = new BufferedReader(new InputStreamReader(in));
             DataOutputStream dos = new DataOutputStream(out);
+            HttpResponse response = new HttpResponse(dos);
 
             Map<String, String> headers = parseRequestHeader(br);
             String requestLine = headers.get("Request-Line");
             if (requestLine == null || requestLine.isEmpty()) {
-                send400Response(dos);
+                response.send400();
                 return;
             }
 
             String[] tokens = requestLine.split(" ");
             if (tokens.length < 2) {
-                send400Response(dos);
+                response.send400();
                 return;
             }
 
@@ -82,14 +84,11 @@ public class RequestHandler implements Runnable {
                 // 파일을 읽어 응답 본문에 담음
                 byte[] body = fileIn.readAllBytes();
                 String contentType = getContentType(uri);
-                response200Header(dos, body.length, contentType);
-                responseBody(dos, body);
+                response.sendResponse(200, "OK", contentType, body);
+
             } else {
                 logger.error("File not found: static{}", uri);
-                String notFoundHtml = "<h1>404 Not Found</h1>";
-                byte[] notFoundBody = notFoundHtml.getBytes();
-                response404Header(dos, notFoundBody.length, "text/html;charset=utf-8");
-                responseBody(dos, notFoundBody);
+                response.send404();
             }
         } catch (IOException e) {
             logger.error(e.getMessage());
@@ -149,49 +148,4 @@ public class RequestHandler implements Runnable {
         }
     }
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {
-        try {
-            dos.writeBytes("HTTP/1.1 200 OK\r\n");
-            dos.writeBytes("Content-Type: " + contentType + "\r\n");
-            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
-            dos.writeBytes("\r\n");
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private void responseBody(DataOutputStream dos, byte[] body) {
-        try {
-            dos.write(body, 0, body.length);
-            dos.flush();
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private void response404Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {
-        try {
-            dos.writeBytes("HTTP/1.1 404 Not Found\r\n");
-            dos.writeBytes("Content-Type: " + contentType + "\r\n");
-            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
-            dos.writeBytes("\r\n");
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private void send400Response(DataOutputStream dos) {
-        String badRequestHtml = "<h1>400 Bad Request</h1>";
-        byte[] badRequestBody = badRequestHtml.getBytes();
-        try {
-            dos.writeBytes("HTTP/1.1 400 Bad Request\r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
-            dos.writeBytes("Content-Length: " + badRequestBody.length + "\r\n");
-            dos.writeBytes("\r\n");
-            dos.write(badRequestBody);
-            dos.flush();
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
-    private Socket connection;
+    private final Socket connection;
 
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
@@ -43,13 +43,14 @@ public class RequestHandler implements Runnable {
             if (fileIn != null) {
                 // 파일을 읽어 응답 본문에 담음
                 byte[] body = fileIn.readAllBytes();
-                response200Header(dos, body.length);
+                String contentType = getContentType(uri);
+                response200Header(dos, body.length, contentType);
                 responseBody(dos, body);
             } else {
                 logger.error("File not found: static{}", uri);
                 String notFoundHtml = "<h1>404 Not Found</h1>";
                 byte[] notFoundBody = notFoundHtml.getBytes();
-                response404Header(dos, notFoundBody.length);
+                response404Header(dos, notFoundBody.length, "text/html;charset=utf-8");
                 responseBody(dos, notFoundBody);
             }
         } catch (IOException e) {
@@ -80,10 +81,38 @@ public class RequestHandler implements Runnable {
         return headers;
     }
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
+    private String getContentType(String uri) {
+        String lowerUri = uri.toLowerCase();
+
+        if (lowerUri.endsWith(".html") || lowerUri.endsWith(".htm")) {
+            return "text/html;charset=utf-8";
+        } else if (lowerUri.endsWith(".css")) {
+            return "text/css;charset=utf-8";
+        } else if (lowerUri.endsWith(".js")) {
+            return "application/javascript;charset=utf-8";
+        } else if (lowerUri.endsWith(".png")) {
+            return "image/png";
+        } else if (lowerUri.endsWith(".svg")) {
+            return "image/svg+xml";
+        } else if (lowerUri.endsWith(".ico")) {
+            return "image/x-icon";
+        } else if (lowerUri.endsWith(".jpg") || lowerUri.endsWith(".jpeg")) {
+            return "image/jpeg";
+        } else if (lowerUri.endsWith(".gif")) {
+            return "image/gif";
+        } else if (lowerUri.endsWith(".json")) {
+            return "application/json;charset=utf-8";
+        } else if (lowerUri.endsWith(".xml")) {
+            return "application/xml;charset=utf-8";
+        } else {
+            return "application/octet-stream";
+        }
+    }
+
+    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {
         try {
-            dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("HTTP/1.1 200 OK\r\n");
+            dos.writeBytes("Content-Type: " + contentType + "\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {
@@ -100,9 +129,9 @@ public class RequestHandler implements Runnable {
         }
     }
 
-    private void response404Header(DataOutputStream dos, int lengthOfBodyContent) throws IOException {
+    private void response404Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) throws IOException {
         dos.writeBytes("HTTP/1.1 404 Not Found\r\n");
-        dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+        dos.writeBytes("Content-Type: " + contentType + "\r\n");
         dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
         dos.writeBytes("\r\n");
     }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -26,10 +26,32 @@ public class RequestHandler implements Runnable {
             DataOutputStream dos = new DataOutputStream(out);
 
             Map<String, String> headers = parseRequestHeader(br);
+            String requestLine = headers.get("Request-Line");
+            if (requestLine == null || requestLine.isEmpty()) {
+                send400Response(dos);
+                return;
+            }
 
-            byte[] body = "<h1>Hello World</h1>".getBytes();
-            response200Header(dos, body.length);
-            responseBody(dos, body);
+            String[] tokens = requestLine.split(" ");
+            if (tokens.length < 2) {
+                send400Response(dos);
+                return;
+            }
+
+            String uri = tokens[1];
+            InputStream fileIn = getClass().getClassLoader().getResourceAsStream("static" + uri);
+            if (fileIn != null) {
+                // 파일을 읽어 응답 본문에 담음
+                byte[] body = fileIn.readAllBytes();
+                response200Header(dos, body.length);
+                responseBody(dos, body);
+            } else {
+                logger.error("File not found: static{}", uri);
+                String notFoundHtml = "<h1>404 Not Found</h1>";
+                byte[] notFoundBody = notFoundHtml.getBytes();
+                response404Header(dos, notFoundBody.length);
+                responseBody(dos, notFoundBody);
+            }
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
@@ -76,5 +98,23 @@ public class RequestHandler implements Runnable {
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
+    }
+
+    private void response404Header(DataOutputStream dos, int lengthOfBodyContent) throws IOException {
+        dos.writeBytes("HTTP/1.1 404 Not Found\r\n");
+        dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+        dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
+        dos.writeBytes("\r\n");
+    }
+
+    private void send400Response(DataOutputStream dos) throws IOException {
+        String badRequestHtml = "<h1>400 Bad Request</h1>";
+        byte[] badRequestBody = badRequestHtml.getBytes();
+        dos.writeBytes("HTTP/1.1 400 Bad Request\r\n");
+        dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+        dos.writeBytes("Content-Length: " + badRequestBody.length + "\r\n");
+        dos.writeBytes("\r\n");
+        dos.write(badRequestBody);
+        dos.flush();
     }
 }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -2,6 +2,8 @@ package webserver;
 
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,13 +12,15 @@ public class WebServer {
     private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
     private static final int DEFAULT_PORT = 8080;
 
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
         int port = 0;
         if (args == null || args.length == 0) {
             port = DEFAULT_PORT;
         } else {
             port = Integer.parseInt(args[0]);
         }
+
+        ExecutorService executor = Executors.newFixedThreadPool(10);
 
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.
         try (ServerSocket listenSocket = new ServerSocket(port)) {
@@ -25,8 +29,7 @@ public class WebServer {
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+                executor.submit(new RequestHandler(connection));
             }
         }
     }

--- a/src/main/java/webserver/http/HttpRequest.java
+++ b/src/main/java/webserver/http/HttpRequest.java
@@ -2,6 +2,7 @@ package webserver.http;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.http.exception.RequestParseException;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -21,13 +22,13 @@ public class HttpRequest {
 
         String requestLine = reader.readLine();
         if (requestLine == null || requestLine.isEmpty()) {
-            throw new IOException("Empty request line");
+            throw new RequestParseException("Empty request line");
         }
         logger.debug("Request line: {}", requestLine);
 
         String[] tokens = requestLine.split(" ");
         if (tokens.length < 3) {
-            throw new IOException("Invalid request line: " + requestLine);
+            throw new RequestParseException("Invalid request line: " + requestLine);
         }
 
         this.method = tokens[0];

--- a/src/main/java/webserver/http/HttpRequest.java
+++ b/src/main/java/webserver/http/HttpRequest.java
@@ -1,0 +1,65 @@
+package webserver.http;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpRequest {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpRequest.class);
+    private final String method;
+    private final String uri;
+    private final String protocol;
+    private final Map<String, String> headers;
+
+    public HttpRequest(BufferedReader reader) throws IOException {
+        headers = new HashMap<>();
+
+        String requestLine = reader.readLine();
+        if (requestLine == null || requestLine.isEmpty()) {
+            throw new IOException("Empty request line");
+        }
+        logger.debug("Request line: {}", requestLine);
+
+        String[] tokens = requestLine.split(" ");
+        if (tokens.length < 3) {
+            throw new IOException("Invalid request line: " + requestLine);
+        }
+
+        this.method = tokens[0];
+        this.uri = tokens[1];
+        this.protocol = tokens[2];
+
+        String line;
+        while ((line = reader.readLine()) != null && !line.isEmpty()) {
+            logger.debug("Header line: {}", line);
+            int colonIndex = line.indexOf(":");
+            if (colonIndex != -1) {
+                String key = line.substring(0, colonIndex).trim();
+                String value = line.substring(colonIndex + 1).trim();
+                headers.put(key, value);
+            }
+        }
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+}

--- a/src/main/java/webserver/http/HttpResponse.java
+++ b/src/main/java/webserver/http/HttpResponse.java
@@ -1,0 +1,39 @@
+package webserver.http;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.logging.Logger;
+
+public class HttpResponse {
+
+    private static final Logger logger = Logger.getLogger(HttpResponse.class.getName());
+    private final DataOutputStream dos;
+
+    public HttpResponse(DataOutputStream dos) {
+        this.dos = dos;
+    }
+
+    public void sendResponse(int statusCode, String statusText, String contentType, byte[] body) {
+        try {
+            dos.writeBytes("HTTP/1.1 " + statusCode + " " + statusText + "\r\n");
+            dos.writeBytes("Content-Type: " + contentType + "\r\n");
+            dos.writeBytes("Content-Length: " + body.length + "\r\n");
+            dos.writeBytes("\r\n");
+            dos.write(body, 0, body.length);
+            dos.flush();
+        } catch (IOException e) {
+            logger.severe("Error sending response: " + e.getMessage());
+        }
+    }
+
+    public void send400() {
+        String msg = "<h1>400 Bad Request</h1>";
+        sendResponse(400, "Bad Request", "text/html;charset=utf-8", msg.getBytes());
+    }
+
+    public void send404() {
+        String msg = "<h1>404 Not Found</h1>";
+        sendResponse(404, "Not Found", "text/html;charset=utf-8", msg.getBytes());
+    }
+
+}

--- a/src/main/java/webserver/http/exception/RequestParseException.java
+++ b/src/main/java/webserver/http/exception/RequestParseException.java
@@ -1,0 +1,9 @@
+package webserver.http.exception;
+
+import java.io.IOException;
+
+public class RequestParseException extends IllegalStateException {
+    public RequestParseException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/webserver/resolver/ResourceResolver.java
+++ b/src/main/java/webserver/resolver/ResourceResolver.java
@@ -1,0 +1,65 @@
+package webserver.resolver;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import webserver.http.HttpRequest;
+import webserver.http.HttpResponse;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public class ResourceResolver {
+
+    private static final Logger logger = LoggerFactory.getLogger(ResourceResolver.class);
+    private static final String BASE_PATH = "static";
+    private final HttpRequest request;
+    private final HttpResponse response;
+
+    public ResourceResolver(HttpRequest request, HttpResponse response) {
+        this.request = request;
+        this.response = response;
+    }
+
+    public void resolve() throws IOException {
+        String uri = request.getUri();
+
+        InputStream fileIn = getClass().getClassLoader().getResourceAsStream(BASE_PATH + uri);
+        if (fileIn != null) {
+            byte[] body = fileIn.readAllBytes();
+            String contentType = getContentType(uri);
+            response.sendResponse(200, "OK", contentType, body);
+
+        } else {
+            logger.error("File not found: static{}", uri);
+            response.send404();
+        }
+    }
+
+    private String getContentType(String uri) {
+        String lowerUri = uri.toLowerCase();
+        if (lowerUri.endsWith(".html") || lowerUri.endsWith(".htm")) {
+            return "text/html;charset=utf-8";
+        } else if (lowerUri.endsWith(".css")) {
+            return "text/css;charset=utf-8";
+        } else if (lowerUri.endsWith(".js")) {
+            return "application/javascript;charset=utf-8";
+        } else if (lowerUri.endsWith(".png")) {
+            return "image/png";
+        } else if (lowerUri.endsWith(".svg")) {
+            return "image/svg+xml";
+        } else if (lowerUri.endsWith(".ico")) {
+            return "image/x-icon";
+        } else if (lowerUri.endsWith(".jpg") || lowerUri.endsWith(".jpeg")) {
+            return "image/jpeg";
+        } else if (lowerUri.endsWith(".gif")) {
+            return "image/gif";
+        } else if (lowerUri.endsWith(".json")) {
+            return "application/json;charset=utf-8";
+        } else if (lowerUri.endsWith(".xml")) {
+            return "application/xml;charset=utf-8";
+        } else {
+            return "application/octet-stream";
+        }
+    }
+
+}

--- a/src/test/java/webserver/http/HttpRequestTest.java
+++ b/src/test/java/webserver/http/HttpRequestTest.java
@@ -1,0 +1,51 @@
+package webserver.http;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import webserver.http.exception.RequestParseException;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+
+class HttpRequestTest {
+
+    @Test
+    @DisplayName("정상 요청 문자열 파싱: 올바른 메서드, URI, 프로토콜 및 헤더를 추출해야 한다.")
+    public void 헤더_정상_파싱_테스트() throws Exception {
+        // Given
+        String requestStr =
+                """
+                        GET /index.html HTTP/1.1\r
+                        Host: localhost\r
+                        User-Agent: TestAgent\r
+                        \r
+                        """;
+        BufferedReader reader = new BufferedReader(new StringReader(requestStr));
+
+        // When
+        HttpRequest request = new HttpRequest(reader);
+
+        // Then
+        Assertions.assertThat(request.getMethod()).isEqualTo("GET");
+        Assertions.assertThat(request.getUri()).isEqualTo("/index.html");
+        Assertions.assertThat(request.getProtocol()).isEqualTo("HTTP/1.1");
+        Assertions.assertThat(request.getHeaders())
+                .containsEntry("Host", "localhost")
+                .containsEntry("User-Agent", "TestAgent");
+    }
+
+    @Test
+    @DisplayName("빈 요청 문자열 파싱 시: RequestParseException 예외가 발생해야 한다.")
+    public void 헤더_파싱_예외_테스트() {
+        // Given
+        String requestStr = "\r\n";
+        BufferedReader reader = new BufferedReader(new StringReader(requestStr));
+
+        // When & Then
+        Assertions.assertThatThrownBy(() -> new HttpRequest(reader))
+                .isInstanceOf(RequestParseException.class)
+                .hasMessageContaining("Empty request line");
+    }
+
+}

--- a/src/test/java/webserver/http/HttpResponseTest.java
+++ b/src/test/java/webserver/http/HttpResponseTest.java
@@ -1,0 +1,64 @@
+package webserver.http;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+class HttpResponseTest {
+
+    private HttpResponse response;
+    private ByteArrayOutputStream baos;
+
+    @BeforeEach
+    void setUp() {
+        this.baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+        response = new HttpResponse(dos);
+    }
+
+    @Test
+    @DisplayName("올바른 응답 정보가 주어졌을 때, 200 OK 응답과 올바른 헤더 및 본문이 전송되어야 한다.")
+    public void 올바른_응답_200_응답_테스트() throws IOException {
+        // Given
+        String body = "Hello World";
+
+        // When
+        response.sendResponse(200, "OK", "text/plain", body.getBytes(StandardCharsets.UTF_8));
+
+        // Then
+        String output = baos.toString(StandardCharsets.UTF_8);
+        Assertions.assertThat(output).contains("HTTP/1.1 200 OK");
+        Assertions.assertThat(output).contains("Content-Type: text/plain");
+        Assertions.assertThat(output).contains("Content-Length: " + body.getBytes().length);
+        Assertions.assertThat(output).endsWith("Hello World");
+    }
+
+    @Test
+    @DisplayName("send400() 호출 시, 400 Bad Request 응답이 전송되어야 한다.")
+    public void 응답_400_테스트() throws IOException {
+        // When
+        response.send400();
+
+        // Then
+        String output = baos.toString(StandardCharsets.UTF_8);
+        Assertions.assertThat(output).contains("400 Bad Request");
+    }
+
+    @Test
+    @DisplayName("send404() 호출 시, 404 Not Found 응답이 전송되어야 한다.")
+    public void 응답_404_테스트() throws IOException {
+        // When
+        response.send404();
+
+        // Then
+        String output = baos.toString();
+        Assertions.assertThat(output).contains("404 Not Found");
+    }
+
+}

--- a/src/test/java/webserver/resolver/ResourceResolverTest.java
+++ b/src/test/java/webserver/resolver/ResourceResolverTest.java
@@ -1,0 +1,67 @@
+package webserver.resolver;
+
+import webserver.http.HttpRequest;
+import webserver.http.HttpResponse;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.StringReader;
+
+class ResourceResolverTest {
+
+    @Test
+    @DisplayName("존재하는 리소스 요청이 주어졌을 때, 200 OK 응답과 파일 내용이 전송되어야 한다.")
+    public void 올바른_리소스_요청_200_응답_반환_테스트() throws Exception {
+        // Given
+        String requestStr =
+                """
+                        GET /index.html HTTP/1.1\r
+                        Host: localhost\r
+                        \r
+                        """;
+        BufferedReader br = new BufferedReader(new StringReader(requestStr));
+        HttpRequest request = new HttpRequest(br);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+        HttpResponse response = new HttpResponse(dos);
+
+        // When
+        ResourceResolver resolver = new ResourceResolver(request, response);
+        resolver.resolve();
+
+        // Then
+        String output = baos.toString();
+        Assertions.assertThat(output).contains("200 OK");
+        Assertions.assertThat(output).contains("text/html");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 리소스 요청이 주어졌을 때, 404 Not Found 응답이 전송되어야 한다.")
+    public void 존재하지_않은_리소스_404응답_반환_테스트() throws Exception {
+        // Given
+        String requestStr =
+                """
+                        GET /nonexistent.txt HTTP/1.1\r
+                        Host: localhost\r
+                        \r
+                        """;
+        BufferedReader br = new BufferedReader(new StringReader(requestStr));
+        HttpRequest request = new HttpRequest(br);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+        HttpResponse response = new HttpResponse(dos);
+
+        // When
+        ResourceResolver resolver = new ResourceResolver(request, response);
+        resolver.resolve();
+
+        // Then
+        String output = baos.toString();
+        Assertions.assertThat(output).contains("404 Not Found");
+    }
+
+}


### PR DESCRIPTION
## 구현 내용 

### HTTP 요청/응답 처리

- `HttpRequest` 클래스
  - 클라이언트 스트림에서 요청 라인과 헤더를 파싱하고, 메서드, URI, 프로토콜, 헤더 정보를 캡슐화

- `HttpResponse` 클래스
  - 응답 헤더 및 본문 전송 로직 구현(200 OK, 400 Bad Request, 404 Not Found 처리)

### 정적 리소스 처리

- `ResourceResolver` 클래스
  - 클래스패스(static 폴더)에서 요청된 리소스를 찾아 응답으로 전달
  - 리소스가 존재하지 않을 경우 404 Not Found 응답
  - 리소스가 존재할 경우 `HttpResponse` 객체에 리소스를 설정하여 응답

### ContentType 처리

- Resource를 기준으로 확장자를 확인해 어떤 리소스인지 판별하고 `ContentType`을 설정하는 로직 구현.

## 고민 사항

웹 서버에서는 일반적으로 디렉토리 요청 시 자동으로 index.html(혹은 welcome file)을 반환합니다. 하지만 Tomcat을 비롯한 서블릿 컨테이너는 이를 web.xml의 <welcome-file-list> 로 처리를 하기 때문에 별도의 xml 없이 기본적으로 index.html을 서빙하는 것이 알맞지 않다고 생각해서 구현을 했다가 제거를 했었습니다

이미 한 번 nginx를 간단하게 구현해본 경험이 있어서 그런지 어느 정도의 설계가 머리에 있어서 계속 미래지향적인 코드와 구조가 생각이 드는데 그럼에도 애자일하게 구현하는 것이 맞을지, 아니면 처음부터 확장성을 고려한 구조로 구현하는 것이 맞을지 고민입니다
만약 후자로 하게 됐을 시 너무 많은 테스크와 구현이 남아있어서 과연 이 구조가 맞는지에 대한 의문이 들었습니다. 그래서 일단은 애자일하게 구현을 하되, 나중에 리팩토링을 통해 확장성을 고려한 구조로 바꾸는 것이 좋을 것 같다는 결론을 내렸습니다.

### 기타

index.html을 서빙했을 때 css, svg파일이 로딩이 안 되는게 조금 불편...해서 2단계 내용인줄 모르고 ContentType을 설정하는 로직을 추가했습니다..
