### PR TITLE
[Elbin] step - 1 웹 서버 1단계 - index.html 응답

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -21,6 +21,15 @@ public class RequestHandler implements Runnable {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
+            BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
+            String request = br.readLine();
+            logger.debug("Request received: {}", request);
+
+            while(!request.equals("")){
+                request = br.readLine();
+                logger.debug("Request received: {}", request);
+            }
+
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             DataOutputStream dos = new DataOutputStream(out);
 

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,10 +1,8 @@
 package webserver;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.Socket;
+import java.nio.file.Files;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,7 +23,10 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "<h1>Hello World</h1>".getBytes();
+
+            // 정적 파일 경로 설정 (예: index.html)
+            File file = new File("src/main/resources/static/index.html");
+            byte[] body = Files.readAllBytes(file.toPath());
             response200Header(dos, body.length);
             responseBody(dos, body);
         } catch (IOException e) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -23,6 +23,7 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
             String request = br.readLine();
+            String[] tokens = request.split(" ");
             logger.debug("Request received: {}", request);
 
             while(!request.equals("")){
@@ -34,7 +35,7 @@ public class RequestHandler implements Runnable {
             DataOutputStream dos = new DataOutputStream(out);
 
             // 정적 파일 경로 설정 (예: index.html)
-            File file = new File("src/main/resources/static/index.html");
+            File file = new File("src/main/resources/static" + tokens[1]);
             byte[] body = Files.readAllBytes(file.toPath());
             response200Header(dos, body.length);
             responseBody(dos, body);

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -2,6 +2,8 @@ package webserver;
 
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +11,9 @@ import org.slf4j.LoggerFactory;
 public class WebServer {
     private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
     private static final int DEFAULT_PORT = 8080;
+
+    // 스레드 풀 생성 (예: 최대 50개의 스레드를 사용할 수 있도록 설정)
+    private static final ExecutorService threadPool = Executors.newFixedThreadPool(50);
 
     public static void main(String args[]) throws Exception {
         int port = 0;
@@ -25,8 +30,7 @@ public class WebServer {
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+                threadPool.submit(new RequestHandler(connection));
             }
         }
     }


### PR DESCRIPTION
## 구현 내용
http://localhost:8080/index.html 로 접속했을 때 src/main/resources/static 디렉토리의 index.html 파일을 읽어 클라이언트에 응답할 수 있도록 하였습니다.
Http request의 header 부분을 한 줄씩 파싱하여 로거로 출력할 수 있도록 하였습니다.
java의 Concurrent 패키지를 도입하여 thread 생성과 관리를 더욱 수월하게 하였습니다.

## 구현하며 학습한 내용 

### 🧠 Process & Thread

---

#### 📌 프로세스(Process)

> 메모리에 올라가 CPU 자원을 할당받아 동작 중인 프로그램 인스턴스

##### ✅ OS의 프로세스 동작 원리
1. 사용자가 프로그램을 실행하면 OS는 해당 프로그램의 실행 파일을 메모리에 로드함  
2. OS가 프로세스마다 PCB(Process Control Block)를 사용하여 상태를 관리함  
3. CPU 스케줄러를 통해 프로세스에게 CPU 자원을 할당하여 실행함  
4. 프로세스가 종료되면, 할당된 메모리를 해제하고 PCB를 삭제함  

##### ✅ 프로세스 주요 특징
- 각 프로세스는 **독립된 메모리 공간**을 가짐 (코드, 데이터, 스택, 힙 영역 포함)  
- 다른 프로세스와 메모리를 공유하지 않음  
- 프로세스 간 통신(IPC)은 **복잡하고 비용이 큼** (ex. 소켓, 파이프, 공유 메모리 등)

---

#### 📌 스레드(Thread)

> 프로세스 내에서 실행되는 작은 실행 단위. 프로세스의 자원을 공유하며 독립적으로 실행되는 흐름

##### ✅ OS의 스레드 동작 원리
1. 프로세스가 실행되면 기본적으로 하나의 **메인 스레드**가 함께 생성됨  
2. 개발자가 원하면 **서브 스레드**를 생성 가능 (`Thread` 클래스 또는 `Runnable` 인터페이스 사용)  
3. OS의 **스레드 스케줄러**가 각 스레드에 CPU를 할당 → 병렬/동시 실행 가능  

##### ✅ 스레드 주요 특징
- 하나의 프로세스는 **여러 개의 스레드**를 가질 수 있음 (멀티스레딩)  
- 스레드들은 **프로세스의 코드, 힙 영역을 공유**함 → 같은 데이터에 접근 가능  
- 각각 **독립적인 스택과 레지스터**를 가짐

### JVM과 Thread

- Java에선 스레드마다 스택이 존재  
- 스레드를 실행시켜주려면 반드시 `start()`를 해줘야 함  
- `start()`를 해주지 않으면 스레드가 생성되지 않음 (스레드 스택이 생성되지 않음)  

---

### JVM 스레드 전략

- Native Thread 전략: 운영체제의 스레드 전략을 그대로 사용  
- Java의 스레드는 OS가 관리하는 커널 스레드에 매핑됨  
- 스레드의 스케줄링도 OS에서 관리  
- 과거엔 JVM이 자체적으로 스케줄링을 했지만 (`Green Thread`), 현재는 OS의 스레드 전략을 사용함  
- JVM은 OS의 커널 스레드와 **1:1 매핑 전략**을 사용함  
- `synchronized`를 사용하면 **동기화는 객체 단위로** 걸림

---

### 스레드 매핑 전략 (Thread Mapping Models)

전략 | 설명 | 장점 | 단점
-- | -- | -- | --
1:1 (One-to-One) | 자바 스레드 1개 ↔ OS 스레드 1개 | 병렬 처리 가능, OS 최적화 활용 | 스레드 생성 비용 ↑, 수 제한 가능성
N:1 (Many-to-One) | 자바 스레드 N개 ↔ OS 스레드 1개 | 구현 간단, 문맥 전환 비용 ↓ | 병렬 처리 불가, 하나가 block되면 전체 대기
N:M (Many-to-Many) | 자바 스레드 N개 ↔ OS 스레드 M개 | 유연함, 병렬 처리 가능 | 구현 복잡, 실 사용 거의 없음
