### PR TITLE
[빙빙] step 7-2 다양한 컨텐츠 타입 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@
 - request line의 메소드가 GET이면 요청 url에 해당하는 파일을 리턴한다.
 - ResourceLoader를 인터페이스로 선언하여 File방식과 ClassLoader방식을 사용할 수 있도록 한다.
 
+### 2단계
+- html, css,js, ico, png, jpg contents-type을 지원한다
+- 헤더를 Map에 저장하여 원하는 값들을 쉽게 가져올 수 있도록 만든다
+- Accept 헤더의 값과 파일의 확장자가 같다면 해당 값을 Content-Type으로 설정한다.
+- 예를들어 Accept 헤더가 text/css이고 main.css를 요청하면 response의 Content-Type을 text/css로 바꾼다.
+- ResponseHandler를 만들어 응답을 HttpResponse를 제작한다.
+
 ### 고민 사항
 - index.html 파일을 읽어오는 방법으로 File과 ClassLoader 중 어떤 것을 사용할지 고민했습니다.
  File을 사용하면 파일 시스템의 실제 파일을 직접 읽기 때문에 파일 변경 사항에 즉시 반응할 수 있고, 디버깅이나 개발 과정에서 더 직관적이라는 장점이 있습니다. 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@
 - 헤더를 Map에 저장하여 원하는 값들을 쉽게 가져올 수 있도록 만든다
 - Accept 헤더의 값과 파일의 확장자가 같다면 해당 값을 Content-Type으로 설정한다.
 - 예를들어 Accept 헤더가 text/css이고 main.css를 요청하면 response의 Content-Type을 text/css로 바꾼다.
-- ResponseHandler를 만들어 응답을 HttpResponse를 제작한다.
+- ResponseHandler를 만들어 HttpResponse를 제작한다.
 
 ### 고민 사항
 - index.html 파일을 읽어오는 방법으로 File과 ClassLoader 중 어떤 것을 사용할지 고민했습니다.
  File을 사용하면 파일 시스템의 실제 파일을 직접 읽기 때문에 파일 변경 사항에 즉시 반응할 수 있고, 디버깅이나 개발 과정에서 더 직관적이라는 장점이 있습니다. 
  하지만 애플리케이션을 빌드한 경우, src/main/resources 디렉토리에 있는 파일은 파일 시스템의 독립된 파일이 아니라 JAR 내부에 압축된 리소스가 되므로 File로는 접근할 수 없다는 문제가 있습니다.
  제가 내린 결론은 ResourcesLoader 인터페이스를 만들고 다형성을 이용하여 개발중에는 File, 배포시에는 ClassLoader 방식을 사용한다면 두 방식의 장점을 모두 살릴 수 있을 것 같습니다.
+
+- 헤더들을 Map에 저장하는 작업을 수행하던 중 ,를 이용헤서 각 헤더의 값들을 분류하였습니다. 하지만 ,로 값들을 구분하는게 아닌 ;으로 구분하거나 헤더의 값 자체에 ,를 사용하는 경우가 있었습니다.
+  HTTP 명세상 “comma-separated list”로 정의된 헤더들을 따로 정의하여 해당 헤더들만 ,로 구분하도록 했습니다.

--- a/src/main/java/webserver/ContentTypeResolver.java
+++ b/src/main/java/webserver/ContentTypeResolver.java
@@ -3,6 +3,9 @@ package webserver;
 import java.util.Map;
 
 public class ContentTypeResolver {
+    private static final String EXTENSION_SEPARATOR = "\\.";
+    private static final String DEFAULT_CONTENT_TYPE = "*/*";
+    private static final int EXTENSION_IDX = 1;
 
     private static final Map<String, String> contentTypes = Map.ofEntries(
             Map.entry("html", "text/html;charset=utf-8"),
@@ -16,7 +19,7 @@ public class ContentTypeResolver {
     );
 
     public static String getContentType(String url) {
-        String[] splitUrl = url.split("\\.");
-        return contentTypes.getOrDefault(splitUrl[1], "*/*");
+        String[] splitUrl = url.split(EXTENSION_SEPARATOR);
+        return contentTypes.getOrDefault(splitUrl[EXTENSION_IDX], DEFAULT_CONTENT_TYPE);
     }
 }

--- a/src/main/java/webserver/ContentTypeResolver.java
+++ b/src/main/java/webserver/ContentTypeResolver.java
@@ -1,0 +1,22 @@
+package webserver;
+
+import java.util.Map;
+
+public class ContentTypeResolver {
+
+    private static final Map<String, String> contentTypes = Map.ofEntries(
+            Map.entry("html", "text/html;charset=utf-8"),
+            Map.entry("css", "text/css"),
+            Map.entry("js", "application/javascript"),
+            Map.entry("png", "image/png"),
+            Map.entry("jpg", "image/jpeg"),
+            Map.entry("jpeg", "image/jpeg"),
+            Map.entry("ico", "image/x-icon"),
+            Map.entry("svg", "image/svg+xml")
+    );
+
+    public static String getContentType(String url) {
+        String[] splitUrl = url.split("\\.");
+        return contentTypes.getOrDefault(splitUrl[1], "*/*");
+    }
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -6,13 +6,15 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 
+import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.loader.ResourceLoader;
 
 public class RequestHandler implements Runnable {
-    public static final int METHOD_INDEX = 0;
-    public static final int URL_INDEX = 1;
+    public static final String HTTP_METHOD = "Method";
+    public static final String REQUEST_URL = "Url";
     public static final String GET = "GET";
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
@@ -31,11 +33,9 @@ public class RequestHandler implements Runnable {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
-            String[] requestLine = requestParser.parseRequest(in);
+            Map<String, List<String>> requestMap = requestParser.parseRequest(in);
+            byte[] body = generateBody(requestMap);
 
-            byte[] body = generateBody(requestLine);
-
-            // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             DataOutputStream dos = new DataOutputStream(out);
             response200Header(dos, body.length);
             responseBody(dos, body);
@@ -44,10 +44,10 @@ public class RequestHandler implements Runnable {
         }
     }
 
-    private byte[] generateBody(String[] requestLine) {
+    private byte[] generateBody(Map<String, List<String>> requestMap) {
         byte[] body = new byte[0];
-        if (requestLine[METHOD_INDEX].equals(GET)) {
-            body = resourceLoader.fileToBytes(requestLine[URL_INDEX]);
+        if (requestMap.get(HTTP_METHOD).getFirst().equals(GET)) {
+            body = resourceLoader.fileToBytes(requestMap.get(REQUEST_URL).getFirst());
         }
         return body;
     }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -36,12 +36,14 @@ public class RequestHandler implements Runnable {
             Map<String, List<String>> requestMap = requestParser.parseRequest(in);
             byte[] body = generateBody(requestMap);
 
+            String type = ContentTypeResolver.getContentType(requestMap.get(REQUEST_URL).getFirst());
             DataOutputStream dos = new DataOutputStream(out);
-            response200Header(dos, body.length);
+            response200Header(dos, body.length, type);
             responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
+
     }
 
     private byte[] generateBody(Map<String, List<String>> requestMap) {
@@ -53,10 +55,10 @@ public class RequestHandler implements Runnable {
     }
 
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
+    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String type) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Content-Type: " + type + "\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {

--- a/src/main/java/webserver/RequestParser.java
+++ b/src/main/java/webserver/RequestParser.java
@@ -4,22 +4,68 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RequestParser {
     private static final Logger logger = LoggerFactory.getLogger(RequestParser.class);
+    private final Set<String> commaSeperatedHeaders = Set.of(
+            "Accept", "Accept-Encoding", "Accept-Language",
+            "Cache-Control", "Connection", "Pragma",
+            "TE", "Trailer", "Transfer-Encoding",
+            "Upgrade", "Vary", "Via", "Warning"
+    );
 
-    public String[] parseRequest(InputStream in) throws IOException {
+    public Map<String, List<String>> parseRequest(InputStream in) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(in));
+        Map<String, List<String>> requestMap = new HashMap<>();
+
         String line = br.readLine();
-        String[] requestLine = line.split(" ");
+        parseRequestLine(line, requestMap);
         logger.debug("requestLine : {}", line);
 
         while (!line.isEmpty()) {
             line = br.readLine();
+            parseRequestHeader(line, requestMap);
+
             logger.debug("header : {}", line);
         }
-        return requestLine;
+        return requestMap;
+    }
+
+    private void parseRequestHeader(String line, Map<String, List<String>> requestMap) {
+        int idx = line.indexOf(":");
+        if (idx != -1) {
+            String key = line.substring(0, idx).trim();
+            String value = line.substring(idx + 1).trim();
+            if (commaSeperatedHeaders.contains(key)) {
+                addCommaSeperatedValueToMap(requestMap, value, key);
+            } else {
+                addSingleValueToMap(requestMap, key, value);
+            }
+        }
+
+    }
+
+    private void parseRequestLine(String line, Map<String, List<String>> requestMap) {
+        String[] requestLine = line.split(" ");
+        addSingleValueToMap(requestMap, "Method", requestLine[0]);
+        addSingleValueToMap(requestMap, "Url", requestLine[1]);
+        addSingleValueToMap(requestMap, "Version", requestLine[2]);
+    }
+
+    private void addSingleValueToMap(Map<String, List<String>> requestMap, String key, String value) {
+        requestMap.computeIfAbsent(key, k -> new ArrayList<>()).add(value);
+    }
+
+    private void addCommaSeperatedValueToMap(Map<String, List<String>> requestMap, String values, String key) {
+        for (String value : values.split(",")) {
+            addSingleValueToMap(requestMap, key, value);
+        }
     }
 }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -15,6 +15,7 @@ import webserver.response.ResponseHandler;
 public class WebServer {
     private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
     private static final int DEFAULT_PORT = 8080;
+    private static final int THREAD_COUNT = 10;
 
     public static void main(String args[]) throws Exception {
         int port = 0;
@@ -30,7 +31,7 @@ public class WebServer {
 
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
-            ExecutorService executor = Executors.newFixedThreadPool(10);
+            ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
             while ((connection = listenSocket.accept()) != null) {
                 executor.submit(new RequestHandler(connection, new FileResourceLoader(), new RequestParser(), new ResponseHandler()));
             }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -8,6 +8,9 @@ import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.loader.FileResourceLoader;
+import webserver.request.RequestHandler;
+import webserver.request.RequestParser;
+import webserver.response.ResponseHandler;
 
 public class WebServer {
     private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
@@ -29,7 +32,7 @@ public class WebServer {
             Socket connection;
             ExecutorService executor = Executors.newFixedThreadPool(10);
             while ((connection = listenSocket.accept()) != null) {
-                executor.submit(new RequestHandler(connection, new FileResourceLoader(), new RequestParser()));
+                executor.submit(new RequestHandler(connection, new FileResourceLoader(), new RequestParser(), new ResponseHandler()));
             }
         }
     }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -25,13 +25,14 @@ public class WebServer {
             port = Integer.parseInt(args[0]);
         }
 
+        ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.
         try (ServerSocket listenSocket = new ServerSocket(port)) {
             logger.info("Web Application Server started {} port.", port);
 
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
-            ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
             while ((connection = listenSocket.accept()) != null) {
                 executor.submit(new RequestHandler(connection, new FileResourceLoader(), new RequestParser(), new ResponseHandler()));
             }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -27,8 +27,8 @@ public class WebServer {
 
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
+            ExecutorService executor = Executors.newFixedThreadPool(10);
             while ((connection = listenSocket.accept()) != null) {
-                ExecutorService executor = Executors.newFixedThreadPool(10);
                 executor.submit(new RequestHandler(connection, new FileResourceLoader(), new RequestParser()));
             }
         }

--- a/src/main/java/webserver/loader/ClasspathResourceLoader.java
+++ b/src/main/java/webserver/loader/ClasspathResourceLoader.java
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import webserver.RequestHandler;
+import webserver.request.RequestHandler;
 
 public class ClasspathResourceLoader implements ResourceLoader{
     private static final String PREFIX = "./static";

--- a/src/main/java/webserver/request/RequestHandler.java
+++ b/src/main/java/webserver/request/RequestHandler.java
@@ -1,5 +1,8 @@
 package webserver.request;
 
+import static webserver.request.RequestParser.HTTP_METHOD;
+import static webserver.request.RequestParser.REQUEST_URL;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -13,9 +16,7 @@ import webserver.loader.ResourceLoader;
 import webserver.response.ResponseHandler;
 
 public class RequestHandler implements Runnable {
-    public static final String HTTP_METHOD = "Method";
-    public static final String REQUEST_URL = "Url";
-    public static final String GET = "GET";
+    private static final String GET = "GET";
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
     private final Socket connection;

--- a/src/main/java/webserver/request/RequestHandler.java
+++ b/src/main/java/webserver/request/RequestHandler.java
@@ -1,6 +1,5 @@
-package webserver;
+package webserver.request;
 
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -11,6 +10,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.loader.ResourceLoader;
+import webserver.response.ResponseHandler;
 
 public class RequestHandler implements Runnable {
     public static final String HTTP_METHOD = "Method";
@@ -21,11 +21,13 @@ public class RequestHandler implements Runnable {
     private final Socket connection;
     private final ResourceLoader resourceLoader;
     private final RequestParser requestParser;
+    private final ResponseHandler responseHandler;
 
-    public RequestHandler(Socket connectionSocket, ResourceLoader resourceLoader, RequestParser requestParser) {
+    public RequestHandler(Socket connectionSocket, ResourceLoader resourceLoader, RequestParser requestParser, ResponseHandler responseHandler) {
         this.connection = connectionSocket;
         this.resourceLoader = resourceLoader;
         this.requestParser = requestParser;
+        this.responseHandler = responseHandler;
     }
 
     public void run() {
@@ -36,15 +38,13 @@ public class RequestHandler implements Runnable {
             Map<String, List<String>> requestMap = requestParser.parseRequest(in);
             byte[] body = generateBody(requestMap);
 
-            String type = ContentTypeResolver.getContentType(requestMap.get(REQUEST_URL).getFirst());
-            DataOutputStream dos = new DataOutputStream(out);
-            response200Header(dos, body.length, type);
-            responseBody(dos, body);
+            responseHandler.createResponse(requestMap, out, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
 
     }
+
 
     private byte[] generateBody(Map<String, List<String>> requestMap) {
         byte[] body = new byte[0];
@@ -54,24 +54,4 @@ public class RequestHandler implements Runnable {
         return body;
     }
 
-
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String type) {
-        try {
-            dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: " + type + "\r\n");
-            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
-            dos.writeBytes("\r\n");
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
-
-    private void responseBody(DataOutputStream dos, byte[] body) {
-        try {
-            dos.write(body, 0, body.length);
-            dos.flush();
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
 }

--- a/src/main/java/webserver/request/RequestParser.java
+++ b/src/main/java/webserver/request/RequestParser.java
@@ -1,4 +1,4 @@
-package webserver;
+package webserver.request;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/src/main/java/webserver/request/RequestParser.java
+++ b/src/main/java/webserver/request/RequestParser.java
@@ -13,6 +13,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RequestParser {
+    public static final String HTTP_METHOD = "Method";
+    public static final String REQUEST_URL = "Url";
+    private static final String REQUEST_VERSION = "Version";
+    private static final String COMMA = ",";
+    private static final String BLANK = " ";
+    private static final String COLON = ":";
+    private static final int METHOD_IDX = 0;
+    private static final int URL_IDX = 1;
+    private static final int VERSION_IDX = 2;
+    private static final int HEADER_IDX = 0;
+    private static final int VALUE_IDX = 1;
     private static final Logger logger = LoggerFactory.getLogger(RequestParser.class);
     private final Set<String> commaSeperatedHeaders = Set.of(
             "Accept", "Accept-Encoding", "Accept-Language",
@@ -29,34 +40,30 @@ public class RequestParser {
         parseRequestLine(line, requestMap);
         logger.debug("requestLine : {}", line);
 
-        while (!line.isEmpty()) {
-            line = br.readLine();
+        while ((line = br.readLine()) != null && !line.isEmpty()) {
             parseRequestHeader(line, requestMap);
-
             logger.debug("header : {}", line);
         }
         return requestMap;
     }
 
     private void parseRequestHeader(String line, Map<String, List<String>> requestMap) {
-        int idx = line.indexOf(":");
-        if (idx != -1) {
-            String key = line.substring(0, idx).trim();
-            String value = line.substring(idx + 1).trim();
-            if (commaSeperatedHeaders.contains(key)) {
-                addCommaSeperatedValueToMap(requestMap, value, key);
-            } else {
-                addSingleValueToMap(requestMap, key, value);
-            }
-        }
+        String[] split = line.split(COLON);
+        String key = split[HEADER_IDX].trim();
+        String value = split[VALUE_IDX].trim();
 
+        if (commaSeperatedHeaders.contains(key)) {
+            addCommaSeperatedValueToMap(requestMap, value, key);
+        } else {
+            addSingleValueToMap(requestMap, key, value);
+        }
     }
 
     private void parseRequestLine(String line, Map<String, List<String>> requestMap) {
-        String[] requestLine = line.split(" ");
-        addSingleValueToMap(requestMap, "Method", requestLine[0]);
-        addSingleValueToMap(requestMap, "Url", requestLine[1]);
-        addSingleValueToMap(requestMap, "Version", requestLine[2]);
+        String[] requestLine = line.split(BLANK);
+        addSingleValueToMap(requestMap, HTTP_METHOD, requestLine[METHOD_IDX]);
+        addSingleValueToMap(requestMap, REQUEST_URL, requestLine[URL_IDX]);
+        addSingleValueToMap(requestMap, REQUEST_VERSION, requestLine[VERSION_IDX]);
     }
 
     private void addSingleValueToMap(Map<String, List<String>> requestMap, String key, String value) {
@@ -64,7 +71,7 @@ public class RequestParser {
     }
 
     private void addCommaSeperatedValueToMap(Map<String, List<String>> requestMap, String values, String key) {
-        for (String value : values.split(",")) {
+        for (String value : values.split(COMMA)) {
             addSingleValueToMap(requestMap, key, value);
         }
     }

--- a/src/main/java/webserver/response/ResponseHandler.java
+++ b/src/main/java/webserver/response/ResponseHandler.java
@@ -1,6 +1,6 @@
 package webserver.response;
 
-import static webserver.request.RequestHandler.REQUEST_URL;
+import static webserver.request.RequestParser.REQUEST_URL;
 
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/src/main/java/webserver/response/ResponseHandler.java
+++ b/src/main/java/webserver/response/ResponseHandler.java
@@ -1,0 +1,44 @@
+package webserver.response;
+
+import static webserver.request.RequestHandler.REQUEST_URL;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import webserver.ContentTypeResolver;
+
+public class ResponseHandler {
+    private static final Logger logger = LoggerFactory.getLogger(ResponseHandler.class);
+
+    public void createResponse(Map<String, List<String>> requestMap, OutputStream out, byte[] body) {
+        DataOutputStream dos = new DataOutputStream(out);
+        String type = ContentTypeResolver.getContentType(requestMap.get(REQUEST_URL).getFirst());
+
+        response200Header(dos, body.length, type);
+        responseBody(dos, body);
+    }
+
+    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String type) {
+        try {
+            dos.writeBytes("HTTP/1.1 200 OK \r\n");
+            dos.writeBytes("Content-Type: " + type + "\r\n");
+            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
+            dos.writeBytes("\r\n");
+        } catch (IOException e) {
+            logger.error(e.getMessage());
+        }
+    }
+
+    private void responseBody(DataOutputStream dos, byte[] body) {
+        try {
+            dos.write(body, 0, body.length);
+            dos.flush();
+        } catch (IOException e) {
+            logger.error(e.getMessage());
+        }
+    }
+}

--- a/src/test/java/webserver/RequestParserTest.java
+++ b/src/test/java/webserver/RequestParserTest.java
@@ -7,9 +7,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import webserver.request.RequestParser;
 
 class RequestParserTest {
 

--- a/src/test/java/webserver/RequestParserTest.java
+++ b/src/test/java/webserver/RequestParserTest.java
@@ -5,6 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -24,11 +27,58 @@ class RequestParserTest {
         RequestParser parser = new RequestParser();
 
         // when
-        String[] requestLine = parser.parseRequest(input);
+        Map<String, List<String>> requestMap = parser.parseRequest(input);
 
         // then
-        assertThat(requestLine[0]).isEqualTo("GET");
-        assertThat(requestLine[1]).isEqualTo("/index.html");
-        assertThat(requestLine[2]).isEqualTo("HTTP/1.1");
+        assertThat(requestMap.get("Method").getFirst()).isEqualTo("GET");
+        assertThat(requestMap.get("Url").getFirst()).isEqualTo("/index.html");
+        assertThat(requestMap.get("Version").getFirst()).isEqualTo("HTTP/1.1");
+    }
+
+    @Test
+    @DisplayName(",로 구분되는 헤더는 하나의 키에 각각 저장되어야 한다")
+    void parsingCommaSeperatedTest() throws IOException {
+        // given
+        String httpRequest =
+                "GET /index.html HTTP/1.1\r\n" +
+                        "Host: localhost:8080\r\n" +
+                        "Connection: keep-alive\r\n" +
+                        "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n" +
+                        "\r\n";
+
+        InputStream input = new ByteArrayInputStream(httpRequest.getBytes());
+        RequestParser parser = new RequestParser();
+
+        // when
+        Map<String, List<String>> requestMap = parser.parseRequest(input);
+
+        // then
+        assertThat(requestMap.get("Accept").size()).isEqualTo(4);
+        assertThat(requestMap.get("Accept")).containsExactly("text/html", "application/xhtml+xml", "application/xml;q=0.9", "*/*;q=0.8");
+    }
+
+    @Test
+    @DisplayName(",로 구분되지 않는 헤더는 하나의 값으로 저장한다.")
+    void parsingNotSeperatedTest() throws IOException {
+        // given
+        String httpRequest =
+                "GET /index.html HTTP/1.1\r\n" +
+                        "Host: localhost:8080\r\n" +
+                        "Connection: keep-alive\r\n" +
+                        "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                        + "AppleWebKit/537.36 (KHTML, like Gecko) "
+                        + "Chrome/134.0.0.0 Safari/537.36\r\n" +
+                        "\r\n";
+
+        InputStream input = new ByteArrayInputStream(httpRequest.getBytes());
+        RequestParser parser = new RequestParser();
+
+        // when
+        Map<String, List<String>> requestMap = parser.parseRequest(input);
+
+        // then
+        assertThat(requestMap.get("User-Agent").size()).isEqualTo(1);
+        assertThat(requestMap.get("User-Agent")).containsExactly("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                + "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36");
     }
 }


### PR DESCRIPTION
## 구현 내용
- html, css,js, ico, png, jpg contents-type을 지원한다
- 헤더를 Map에 저장하여 원하는 값들을 쉽게 가져올 수 있도록 만든다
- Accept 헤더의 값과 파일의 확장자가 같다면 해당 값을 Content-Type으로 설정한다.
- ResponseHandler를 만들어 HttpResponse를 제작한다.

## 고민 사항
- 헤더들을 Map에 저장하는 작업을 수행하던 중 ,를 이용헤서 각 헤더의 값들을 분류하였습니다. 하지만 ,로 값들을 구분하는게 아닌 ;으로 구분하거나 헤더의 값 자체에 ,를 사용하는 경우가 있었습니다.
  HTTP 명세상 “comma-separated list”로 정의된 헤더들을 따로 정의하여 해당 헤더들만 ,로 구분하도록 했습니다.

## 기타
공부한 내용
https://github.com/longrunBiin/be-was-neon/wiki/2%EB%8B%A8%EA%B3%84-%EA%B3%B5%EB%B6%80-%EB%82%B4%EC%9A%A9