### PR TITLE
[Glad] Step 7-3 웹 서버 3단계 - GET으로 회원가입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+# idea
+.idea
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml

--- a/README.md
+++ b/README.md
@@ -15,3 +15,21 @@
 ### 구조 변경
 
 - `Thread` 기반 구조에서 `Concurrent` 기반 구조로 변경
+
+## 2. 다양한 컴텐츠 타입 지원
+
+### MIME Type 지원
+
+- `html`, `css`, `js`, `ico`, `png`, `jpg` 에 대한 MIME Type 지원
+
+## 3. GET 회원가입
+
+### GET 으로 회원가입 기능
+
+- `http://localhost:8080/register.html` 접속시 회원가입 폼을 응답
+- Request parameter로 `userId`, `password`, `name`, `email`을 받음
+- 파싱 후 `model.User`클래스에 저장
+
+### 품질 개선
+
+- 유지보수 하기 용이하도록 코드 리팩토링

--- a/build.gradle
+++ b/build.gradle
@@ -18,11 +18,10 @@ repositories {
 dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.8.1'
 
     implementation 'ch.qos.logback:logback-classic:1.2.3'
     testImplementation 'org.assertj:assertj-core:3.16.1'
-
-
 }
 
 test {

--- a/src/main/java/annotation/RequestMapping.java
+++ b/src/main/java/annotation/RequestMapping.java
@@ -1,0 +1,16 @@
+package annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface RequestMapping {
+
+    String method();
+
+    String path();
+
+}

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -5,11 +5,14 @@ import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.http.common.ContentType;
+import webserver.http.exception.HttpException;
 import webserver.http.request.HttpRequest;
-import webserver.http.response.HttpResponse;
-import webserver.http.response.HttpStatusCode;
+import webserver.resolver.ResolveResponse;
 
 import java.util.Map;
+
+import static webserver.http.response.HttpStatusCode.BAD_REQUEST;
+import static webserver.http.response.HttpStatusCode.CONFLICT;
 
 public class Controller {
 
@@ -24,7 +27,7 @@ public class Controller {
     }
 
     // @GetMapping("/create")
-    public void getCreate(HttpRequest request, HttpResponse response) {
+    public ResolveResponse<User> getCreate(HttpRequest request) {
         logger.debug("getCreate");
         Map<String, String> queryString = request.getRequestLine().getQueryString();
         String userId = queryString.get("userId");
@@ -34,19 +37,17 @@ public class Controller {
 
         if (userId == null || name == null || password == null || email == null) {
             logger.debug("userId and name and password and email are null!");
-            response.sendResponse(HttpStatusCode.BAD_REQUEST, ContentType.JSON, "{\"error\": \"Bad Request\"}".getBytes());
-            return;
+            throw new HttpException(BAD_REQUEST);
         }
         if (Database.findUserById(userId) != null) {
             logger.debug("User already exists: {}", userId);
-            response.sendResponse(HttpStatusCode.CONFLICT, ContentType.JSON, "{\"error\": \"User already exists\"}".getBytes());
-            return;
+            throw new HttpException(CONFLICT);
         }
 
         User user = new User(userId, name, password, email);
         Database.addUser(user);
         logger.debug("User created: {}", user);
-        response.sendResponse(HttpStatusCode.CREATED, ContentType.JSON, "{\"success\": \"User created\"}".getBytes());
+        return ResolveResponse.ok(user, ContentType.JSON);
     }
 
 }

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -1,0 +1,34 @@
+package controller;
+
+import db.Database;
+import model.User;
+import webserver.http.request.HttpRequest;
+import webserver.http.response.HttpResponse;
+
+import java.util.Map;
+
+public class Controller {
+
+    // @GetMapping("/create")
+    public void getCreate(HttpRequest request, HttpResponse response) {
+        Map<String, String> queryString = request.getRequestLine().getQueryString();
+        String userId = queryString.get("userId");
+        String name = queryString.get("name");
+        String password = queryString.get("password");
+        String email = queryString.get("email");
+
+        if (userId == null || name == null || password == null || email == null) {
+            response.send400();
+            return;
+        }
+        if (Database.findUserById(userId) != null) {
+            response.sendResponse(409, "Conflict", "text/plain", "User already exists".getBytes());
+            return;
+        }
+
+        User user = new User(userId, name, password, email);
+        Database.addUser(user);
+        response.sendResponse(201, "Created", "text/plain", "User created successfully".getBytes());
+    }
+
+}

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -4,6 +4,7 @@ import db.Database;
 import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.http.common.ContentType;
 import webserver.http.request.HttpRequest;
 import webserver.http.response.HttpResponse;
 import webserver.http.response.HttpStatusCode;
@@ -25,19 +26,19 @@ public class Controller {
 
         if (userId == null || name == null || password == null || email == null) {
             logger.debug("userId and name and password and email are null!");
-            response.sendResponse(HttpStatusCode.BAD_REQUEST, "text/plain", "userId and name and password and email are null!".getBytes());
+            response.sendResponse(HttpStatusCode.BAD_REQUEST, ContentType.JSON, "{\"error\": \"Bad Request\"}".getBytes());
             return;
         }
         if (Database.findUserById(userId) != null) {
             logger.debug("User already exists: {}", userId);
-            response.sendResponse(HttpStatusCode.CONFLICT, "text/plain", "User already exists".getBytes());
+            response.sendResponse(HttpStatusCode.CONFLICT, ContentType.JSON, "{\"error\": \"User already exists\"}".getBytes());
             return;
         }
 
         User user = new User(userId, name, password, email);
         Database.addUser(user);
         logger.debug("User created: {}", user);
-        response.sendResponse(HttpStatusCode.CREATED, "text/plain", "User created successfully".getBytes());
+        response.sendResponse(HttpStatusCode.CREATED, ContentType.JSON, "{\"success\": \"User created\"}".getBytes());
     }
 
 }

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -47,7 +47,7 @@ public class Controller {
         User user = new User(userId, name, password, email);
         Database.addUser(user);
         logger.debug("User created: {}", user);
-        return ResolveResponse.ok(user, ContentType.JSON);
+        return ResolveResponse.ok(ContentType.JSON, user);
     }
 
 }

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.http.request.HttpRequest;
 import webserver.http.response.HttpResponse;
+import webserver.http.response.HttpStatusCode;
 
 import java.util.Map;
 
@@ -24,19 +25,19 @@ public class Controller {
 
         if (userId == null || name == null || password == null || email == null) {
             logger.debug("userId and name and password and email are null!");
-            response.send400();
+            response.sendResponse(HttpStatusCode.BAD_REQUEST, "text/plain", "userId and name and password and email are null!".getBytes());
             return;
         }
         if (Database.findUserById(userId) != null) {
             logger.debug("User already exists: {}", userId);
-            response.sendResponse(409, "Conflict", "text/plain", "User already exists".getBytes());
+            response.sendResponse(HttpStatusCode.CONFLICT, "text/plain", "User already exists".getBytes());
             return;
         }
 
         User user = new User(userId, name, password, email);
         Database.addUser(user);
         logger.debug("User created: {}", user);
-        response.sendResponse(201, "Created", "text/plain", "User created successfully".getBytes());
+        response.sendResponse(HttpStatusCode.CREATED, "text/plain", "User created successfully".getBytes());
     }
 
 }

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -13,7 +13,15 @@ import java.util.Map;
 
 public class Controller {
 
+    private static final Controller instance = new Controller();
     private static final Logger logger = LoggerFactory.getLogger(Controller.class);
+
+    private Controller() {
+    }
+
+    public static Controller getInstance() {
+        return instance;
+    }
 
     // @GetMapping("/create")
     public void getCreate(HttpRequest request, HttpResponse response) {

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -2,6 +2,8 @@ package controller;
 
 import db.Database;
 import model.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import webserver.http.request.HttpRequest;
 import webserver.http.response.HttpResponse;
 
@@ -9,8 +11,11 @@ import java.util.Map;
 
 public class Controller {
 
+    private static final Logger logger = LoggerFactory.getLogger(Controller.class);
+
     // @GetMapping("/create")
     public void getCreate(HttpRequest request, HttpResponse response) {
+        logger.debug("getCreate");
         Map<String, String> queryString = request.getRequestLine().getQueryString();
         String userId = queryString.get("userId");
         String name = queryString.get("name");
@@ -18,16 +23,19 @@ public class Controller {
         String email = queryString.get("email");
 
         if (userId == null || name == null || password == null || email == null) {
+            logger.debug("userId and name and password and email are null!");
             response.send400();
             return;
         }
         if (Database.findUserById(userId) != null) {
+            logger.debug("User already exists: {}", userId);
             response.sendResponse(409, "Conflict", "text/plain", "User already exists".getBytes());
             return;
         }
 
         User user = new User(userId, name, password, email);
         Database.addUser(user);
+        logger.debug("User created: {}", user);
         response.sendResponse(201, "Created", "text/plain", "User created successfully".getBytes());
     }
 

--- a/src/main/java/controller/Handler.java
+++ b/src/main/java/controller/Handler.java
@@ -14,19 +14,18 @@ import java.util.Map;
 import static webserver.http.response.HttpStatusCode.BAD_REQUEST;
 import static webserver.http.response.HttpStatusCode.CONFLICT;
 
-public class Controller {
+public class Handler {
 
-    private static final Controller instance = new Controller();
-    private static final Logger logger = LoggerFactory.getLogger(Controller.class);
+    private static final Handler instance = new Handler();
+    private static final Logger logger = LoggerFactory.getLogger(Handler.class);
 
-    private Controller() {
+    private Handler() {
     }
 
-    public static Controller getInstance() {
+    public static Handler getInstance() {
         return instance;
     }
 
-    // @GetMapping("/create")
     public ResolveResponse<User> getCreate(HttpRequest request) {
         logger.debug("getCreate");
         Map<String, String> queryString = request.getRequestLine().getQueryString();

--- a/src/main/java/db/Database.java
+++ b/src/main/java/db/Database.java
@@ -3,11 +3,11 @@ package db;
 import model.User;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class Database {
-    private static Map<String, User> users = new HashMap<>();
+    private static final Map<String, User> users = new ConcurrentHashMap<>();
 
     public static void addUser(User user) {
         users.put(user.getUserId(), user);

--- a/src/main/java/handler/Handler.java
+++ b/src/main/java/handler/Handler.java
@@ -1,5 +1,6 @@
-package controller;
+package handler;
 
+import webserver.annotation.RequestMapping;
 import db.Database;
 import model.User;
 import org.slf4j.Logger;
@@ -26,6 +27,7 @@ public class Handler {
         return instance;
     }
 
+    @RequestMapping(method = "GET", path = "/create")
     public ResolveResponse<User> getCreate(HttpRequest request) {
         logger.debug("getCreate");
         Map<String, String> queryString = request.getRequestLine().getQueryString();

--- a/src/main/java/webserver/Dispatcher.java
+++ b/src/main/java/webserver/Dispatcher.java
@@ -21,7 +21,7 @@ public class Dispatcher {
     }
 
     public void dispatch() throws IOException {
-        if (request.isResource()) {
+        if (request.isResourceRequest()) {
             logger.debug("Dispatching to ResourceResolver");
             ResourceResolver resourceResolver = new ResourceResolver(request, response);
             resourceResolver.resolve();

--- a/src/main/java/webserver/Dispatcher.java
+++ b/src/main/java/webserver/Dispatcher.java
@@ -25,11 +25,12 @@ public class Dispatcher {
             logger.debug("Dispatching to ResourceResolver");
             ResourceResolver resourceResolver = new ResourceResolver(request, response);
             resourceResolver.resolve();
-        } else {
-            logger.debug("Dispatching to DynamicResolver");
-            DynamicResolver dynamicResolver = new DynamicResolver(request, response);
-            dynamicResolver.resolve();
+            return;
         }
+
+        logger.debug("Dispatching to DynamicResolver");
+        DynamicResolver dynamicResolver = new DynamicResolver(request, response);
+        dynamicResolver.resolve();
     }
 
 }

--- a/src/main/java/webserver/Dispatcher.java
+++ b/src/main/java/webserver/Dispatcher.java
@@ -1,0 +1,35 @@
+package webserver;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import webserver.http.request.HttpRequest;
+import webserver.http.response.HttpResponse;
+import webserver.resolver.DynamicResolver;
+import webserver.resolver.ResourceResolver;
+
+import java.io.IOException;
+
+public class Dispatcher {
+
+    private static final Logger logger = LoggerFactory.getLogger(Dispatcher.class);
+    private final HttpRequest request;
+    private final HttpResponse response;
+
+    public Dispatcher(HttpRequest request, HttpResponse response) {
+        this.request = request;
+        this.response = response;
+    }
+
+    public void dispatch() throws IOException {
+        if (request.isResource()) {
+            logger.debug("Dispatching to ResourceResolver");
+            ResourceResolver resourceResolver = new ResourceResolver(request, response);
+            resourceResolver.resolve();
+        } else {
+            logger.debug("Dispatching to DynamicResolver");
+            DynamicResolver dynamicResolver = new DynamicResolver(request, response);
+            dynamicResolver.resolve();
+        }
+    }
+
+}

--- a/src/main/java/webserver/Dispatcher.java
+++ b/src/main/java/webserver/Dispatcher.java
@@ -2,9 +2,13 @@ package webserver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.http.exception.HttpException;
 import webserver.http.request.HttpRequest;
 import webserver.http.response.HttpResponse;
+import webserver.http.response.HttpStatusCode;
+import webserver.http.response.StatusLine;
 import webserver.resolver.DynamicResolver;
+import webserver.resolver.ResolveResponse;
 import webserver.resolver.Resolver;
 import webserver.resolver.ResourceResolver;
 
@@ -21,9 +25,23 @@ public class Dispatcher {
 
     public HttpResponse dispatch() throws IOException {
         Resolver resolver = determineResolver();
-        HttpResponse response = resolver.resolve();
+        try {
+             ResolveResponse<?> resolveResponse = resolver.resolve();
 
-        return response;
+            return new HttpResponse(
+                    new StatusLine(resolveResponse.getStatusCode()),
+                    resolveResponse.getHeaders(),
+                    (byte[]) resolveResponse.getBody()
+            );
+        } catch (HttpException e) {
+            logger.error("Error during request processing: {}", e.getMessage());
+            ResolveResponse<?> response = handleException(e);
+            return new HttpResponse(
+                    new StatusLine(response.getStatusCode()),
+                    response.getHeaders(),
+                    (byte[]) response.getBody()
+            );
+        }
     }
 
     private Resolver determineResolver() {
@@ -34,6 +52,19 @@ public class Dispatcher {
 
         logger.debug("Dispatching to DynamicResolver");
         return new DynamicResolver(request);
+    }
+
+    private ResolveResponse<?> handleException(HttpException e) {
+        if (e.getStatusCode() == HttpStatusCode.NOT_FOUND) {
+            logger.error("Resource not found: {}", e.getMessage());
+            return ResolveResponse.notFound(HttpStatusCode.NOT_FOUND);
+        } else if (e.getStatusCode() == HttpStatusCode.UNSUPPORTED_MEDIA_TYPE) {
+            logger.error("Unsupported media type: {}", e.getMessage());
+            return ResolveResponse.notFound(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE);
+        } else {
+            logger.error("Bad request: {}", e.getMessage());
+            return ResolveResponse.badRequest(HttpStatusCode.BAD_REQUEST);
+        }
     }
 
 }

--- a/src/main/java/webserver/Dispatcher.java
+++ b/src/main/java/webserver/Dispatcher.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import webserver.http.request.HttpRequest;
 import webserver.http.response.HttpResponse;
 import webserver.resolver.DynamicResolver;
+import webserver.resolver.Resolver;
 import webserver.resolver.ResourceResolver;
 
 import java.io.IOException;
@@ -13,24 +14,26 @@ public class Dispatcher {
 
     private static final Logger logger = LoggerFactory.getLogger(Dispatcher.class);
     private final HttpRequest request;
-    private final HttpResponse response;
 
-    public Dispatcher(HttpRequest request, HttpResponse response) {
+    public Dispatcher(HttpRequest request) {
         this.request = request;
-        this.response = response;
     }
 
-    public void dispatch() throws IOException {
+    public HttpResponse dispatch() throws IOException {
+        Resolver resolver = determineResolver();
+        HttpResponse response = resolver.resolve();
+
+        return response;
+    }
+
+    private Resolver determineResolver() {
         if (request.isResourceRequest()) {
             logger.debug("Dispatching to ResourceResolver");
-            ResourceResolver resourceResolver = new ResourceResolver(request, response);
-            resourceResolver.resolve();
-            return;
+            return new ResourceResolver(request);
         }
 
         logger.debug("Dispatching to DynamicResolver");
-        DynamicResolver dynamicResolver = new DynamicResolver(request, response);
-        dynamicResolver.resolve();
+        return new DynamicResolver(request);
     }
 
 }

--- a/src/main/java/webserver/Dispatcher.java
+++ b/src/main/java/webserver/Dispatcher.java
@@ -2,14 +2,13 @@ package webserver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.http.common.HttpMethod;
 import webserver.http.exception.HttpException;
 import webserver.http.request.HttpRequest;
 import webserver.http.response.HttpResponse;
 import webserver.http.response.StatusLine;
-import webserver.resolver.DynamicResolver;
-import webserver.resolver.ResolveResponse;
-import webserver.resolver.Resolver;
-import webserver.resolver.ResourceResolver;
+import webserver.mapper.HandlerMapper;
+import webserver.resolver.*;
 import webserver.util.Convertor;
 
 import java.io.IOException;
@@ -38,13 +37,17 @@ public class Dispatcher {
     }
 
     private Resolver determineResolver() {
-        if (request.isResourceRequest()) {
+        String path = request.getPath();
+        HttpMethod method = request.getMethod();
+        DynamicHandler handler = HandlerMapper.getInstance().getHandler(method, path);
+
+        if (handler == null) {
             logger.debug("Dispatching to ResourceResolver");
             return new ResourceResolver(request);
         }
 
         logger.debug("Dispatching to DynamicResolver");
-        return new DynamicResolver(request);
+        return new DynamicResolver(request, handler);
     }
 
     private HttpResponse buildHttpResponse(ResolveResponse<?> responseEntity) {

--- a/src/main/java/webserver/Dispatcher.java
+++ b/src/main/java/webserver/Dispatcher.java
@@ -5,12 +5,12 @@ import org.slf4j.LoggerFactory;
 import webserver.http.exception.HttpException;
 import webserver.http.request.HttpRequest;
 import webserver.http.response.HttpResponse;
-import webserver.http.response.HttpStatusCode;
 import webserver.http.response.StatusLine;
 import webserver.resolver.DynamicResolver;
 import webserver.resolver.ResolveResponse;
 import webserver.resolver.Resolver;
 import webserver.resolver.ResourceResolver;
+import webserver.util.Convertor;
 
 import java.io.IOException;
 
@@ -26,21 +26,14 @@ public class Dispatcher {
     public HttpResponse dispatch() throws IOException {
         Resolver resolver = determineResolver();
         try {
-             ResolveResponse<?> resolveResponse = resolver.resolve();
+            ResolveResponse<?> resolveResponse = resolver.resolve();
 
-            return new HttpResponse(
-                    new StatusLine(resolveResponse.getStatusCode()),
-                    resolveResponse.getHeaders(),
-                    (byte[]) resolveResponse.getBody()
-            );
+            return buildHttpResponse(resolveResponse);
         } catch (HttpException e) {
             logger.error("Error during request processing: {}", e.getMessage());
-            ResolveResponse<?> response = handleException(e);
-            return new HttpResponse(
-                    new StatusLine(response.getStatusCode()),
-                    response.getHeaders(),
-                    (byte[]) response.getBody()
-            );
+            ResolveResponse<?> errorResponse = ResolveResponse.status(e.getStatusCode());
+
+            return buildHttpResponse(errorResponse);
         }
     }
 
@@ -54,17 +47,12 @@ public class Dispatcher {
         return new DynamicResolver(request);
     }
 
-    private ResolveResponse<?> handleException(HttpException e) {
-        if (e.getStatusCode() == HttpStatusCode.NOT_FOUND) {
-            logger.error("Resource not found: {}", e.getMessage());
-            return ResolveResponse.notFound(HttpStatusCode.NOT_FOUND);
-        } else if (e.getStatusCode() == HttpStatusCode.UNSUPPORTED_MEDIA_TYPE) {
-            logger.error("Unsupported media type: {}", e.getMessage());
-            return ResolveResponse.notFound(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE);
-        } else {
-            logger.error("Bad request: {}", e.getMessage());
-            return ResolveResponse.badRequest(HttpStatusCode.BAD_REQUEST);
-        }
+    private HttpResponse buildHttpResponse(ResolveResponse<?> responseEntity) {
+        return new HttpResponse(
+                new StatusLine(responseEntity.getStatusCode()),
+                responseEntity.getHeaders(),
+                Convertor.convertToByteArray(responseEntity.getBody())
+        );
     }
 
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -26,14 +26,16 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             BufferedReader br = new BufferedReader(new InputStreamReader(in));
             DataOutputStream dos = new DataOutputStream(out);
-            HttpResponse response = new HttpResponse(dos);
 
             ABNFRequestParser requestParser = new ABNFRequestParser(br);
             HttpRequest request = requestParser.parseRequest();
             logger.debug("Request: {}", request);
 
-            Dispatcher dispatcher = new Dispatcher(request, response);
-            dispatcher.dispatch();
+            Dispatcher dispatcher = new Dispatcher(request);
+            HttpResponse response = dispatcher.dispatch();
+            dos.writeBytes(response.toString());
+            dos.flush();
+            logger.debug("Response: {}", response);
         } catch (IOException e) {
             logger.error("Error initializing streams: {}", e.getMessage());
         } catch (RequestParseException e) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -6,8 +6,8 @@ import java.net.Socket;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.resolver.ResourceResolver;
-import webserver.http.HttpRequest;
-import webserver.http.HttpResponse;
+import webserver.http.request.HttpRequest;
+import webserver.http.response.HttpResponse;
 
 public class RequestHandler implements Runnable {
 

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -28,8 +28,8 @@ public class RequestHandler implements Runnable {
             HttpResponse response = new HttpResponse(dos);
 
             HttpRequest request = new HttpRequest(br);
-            ResourceResolver resourceResolver = new ResourceResolver(request, response);
-            resourceResolver.resolve();
+            Dispatcher dispatcher = new Dispatcher(request, response);
+            dispatcher.dispatch();
         } catch (IOException e) {
             logger.error("Error initializing streams: {}", e.getMessage());
         }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -33,7 +33,7 @@ public class RequestHandler implements Runnable {
 
             Dispatcher dispatcher = new Dispatcher(request);
             HttpResponse response = dispatcher.dispatch();
-            dos.writeBytes(response.toString());
+            dos.write(response.getBytes());
             dos.flush();
             logger.debug("Response: {}", response);
         } catch (IOException e) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -5,7 +5,8 @@ import java.net.Socket;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import webserver.resolver.ResourceResolver;
+import webserver.http.exception.RequestParseException;
+import webserver.http.request.ABNFRequestParser;
 import webserver.http.request.HttpRequest;
 import webserver.http.response.HttpResponse;
 
@@ -27,11 +28,16 @@ public class RequestHandler implements Runnable {
             DataOutputStream dos = new DataOutputStream(out);
             HttpResponse response = new HttpResponse(dos);
 
-            HttpRequest request = new HttpRequest(br);
+            ABNFRequestParser requestParser = new ABNFRequestParser(br);
+            HttpRequest request = requestParser.parseRequest();
+            logger.debug("Request: {}", request);
+
             Dispatcher dispatcher = new Dispatcher(request, response);
             dispatcher.dispatch();
         } catch (IOException e) {
             logger.error("Error initializing streams: {}", e.getMessage());
+        } catch (RequestParseException e) {
+            logger.error("Error parsing request: {}", e.getMessage());
         }
     }
 

--- a/src/main/java/webserver/annotation/RequestMapping.java
+++ b/src/main/java/webserver/annotation/RequestMapping.java
@@ -1,4 +1,4 @@
-package annotation;
+package webserver.annotation;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/src/main/java/webserver/http/HttpResponse.java
+++ b/src/main/java/webserver/http/HttpResponse.java
@@ -36,4 +36,9 @@ public class HttpResponse {
         sendResponse(404, "Not Found", "text/html;charset=utf-8", msg.getBytes());
     }
 
+    public void send415() {
+        String msg = "<h1>415 Unsupported Media Type</h1>";
+        sendResponse(415, "Unsupported Media Type", "text/html;charset=utf-8", msg.getBytes());
+    }
+
 }

--- a/src/main/java/webserver/http/common/ContentType.java
+++ b/src/main/java/webserver/http/common/ContentType.java
@@ -10,7 +10,7 @@ public enum ContentType {
     SVG("image/svg+xml", ".svg"),
     ICO("image/x-icon", ".ico"),
     JPEG("image/jpeg", ".jpeg"),
-    JPG("image/jpeg", ".jpg"),
+    JPG("image/jpg", ".jpg"),
     GIF("image/gif", ".gif"),
     JSON("application/json;charset=utf-8", ".json"),
     XML("application/xml;charset=utf-8", ".xml"),
@@ -30,7 +30,7 @@ public enum ContentType {
 
     public static boolean matches(String uri) {
         for (ContentType ct : values()) {
-            if (uri.toLowerCase().endsWith(ct.mimeType)) {
+            if (uri.toLowerCase().endsWith(ct.extensions)) {
                 return true;
             }
         }
@@ -39,7 +39,7 @@ public enum ContentType {
 
     public static String getContentType(String uri) {
         for (ContentType ct : values()) {
-            if (matches(uri)) {
+            if (uri.toLowerCase().endsWith(ct.extensions)) {
                 return ct.getMimeType();
             }
         }

--- a/src/main/java/webserver/http/common/ContentType.java
+++ b/src/main/java/webserver/http/common/ContentType.java
@@ -37,14 +37,14 @@ public enum ContentType {
         return false;
     }
 
-    public static String getContentType(String uri) {
+    public static ContentType getContentType(String uri) {
         for (ContentType ct : values()) {
             if (uri.toLowerCase().endsWith(ct.extensions)) {
-                return ct.getMimeType();
+                return ct;
             }
         }
 
-        return DEFAULT.getMimeType();
+        return DEFAULT;
     }
 
 }

--- a/src/main/java/webserver/http/common/ContentType.java
+++ b/src/main/java/webserver/http/common/ContentType.java
@@ -14,6 +14,7 @@ public enum ContentType {
     GIF("image/gif", ".gif"),
     JSON("application/json;charset=utf-8", ".json"),
     XML("application/xml;charset=utf-8", ".xml"),
+    TEXT("text/plain;charset=utf-8", ".txt"),
     DEFAULT("application/octet-stream", ".bin");
 
     private final String mimeType;

--- a/src/main/java/webserver/http/common/ContentType.java
+++ b/src/main/java/webserver/http/common/ContentType.java
@@ -1,0 +1,50 @@
+package webserver.http.common;
+
+public enum ContentType {
+
+    HTML("text/html;charset=utf-8", ".html"),
+    HTM("text/html;charset=utf-8", ".htm"),
+    CSS("text/css;charset=utf-8", ".css"),
+    JS("application/javascript;charset=utf-8", ".js"),
+    PNG("image/png", ".png"),
+    SVG("image/svg+xml", ".svg"),
+    ICO("image/x-icon", ".ico"),
+    JPEG("image/jpeg", ".jpeg"),
+    JPG("image/jpeg", ".jpg"),
+    GIF("image/gif", ".gif"),
+    JSON("application/json;charset=utf-8", ".json"),
+    XML("application/xml;charset=utf-8", ".xml"),
+    DEFAULT("application/octet-stream", ".bin");
+
+    private final String mimeType;
+    private final String extensions;
+
+    ContentType(String mimeType, String extensions) {
+        this.mimeType = mimeType;
+        this.extensions = extensions;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public static boolean matches(String uri) {
+        for (ContentType ct : values()) {
+            if (uri.toLowerCase().endsWith(ct.mimeType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static String getContentType(String uri) {
+        for (ContentType ct : values()) {
+            if (matches(uri)) {
+                return ct.getMimeType();
+            }
+        }
+
+        return DEFAULT.getMimeType();
+    }
+
+}

--- a/src/main/java/webserver/http/common/HttpConstants.java
+++ b/src/main/java/webserver/http/common/HttpConstants.java
@@ -1,0 +1,17 @@
+package webserver.http.common;
+
+public class HttpConstants {
+
+    private HttpConstants() {
+    }
+
+    public static final String AMPERSAND = "&";
+    public static final String EQUALS = "=";
+    public static final String SPACE = " ";
+    public static final String EMPTY = "";
+    public static final String COLON = ":";
+    public static final String DOT = ".";
+    public static final String CR = "\r";
+    public static final String LF = "\n";
+
+}

--- a/src/main/java/webserver/http/common/HttpHeaders.java
+++ b/src/main/java/webserver/http/common/HttpHeaders.java
@@ -10,6 +10,7 @@ import java.util.Map;
 public class HttpHeaders {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpHeaders.class.getName());
+    private static final String CONTENT_TYPE = "Content-Type";
     private final Map<String, String> headers;
 
     public HttpHeaders() {
@@ -18,6 +19,10 @@ public class HttpHeaders {
 
     public void add(String key, String value) {
         headers.put(key, value);
+    }
+
+    public void addContentType(ContentType contentType) {
+        headers.put(CONTENT_TYPE, contentType.getMimeType());
     }
 
     public boolean containsKey(String key) {

--- a/src/main/java/webserver/http/common/HttpHeaders.java
+++ b/src/main/java/webserver/http/common/HttpHeaders.java
@@ -1,0 +1,45 @@
+package webserver.http.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import webserver.http.exception.HeaderNotFoundException;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpHeaders {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpHeaders.class.getName());
+    private final Map<String, String> headers;
+
+    public HttpHeaders() {
+        this.headers = new HashMap<>();
+    }
+
+    public void add(String key, String value) {
+        headers.put(key, value);
+    }
+
+    public boolean containsKey(String key) {
+        return headers.containsKey(key);
+    }
+
+    public String get(String fieldName) {
+        if (!headers.containsKey(fieldName)) {
+            logger.error("Header에 {}이 존재하지않습니다.", fieldName);
+            throw new HeaderNotFoundException("Header에 " + fieldName + "이 존재하지않습니다.");
+        }
+
+        return headers.get(fieldName);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            sb.append(entry.getKey()).append(": ").append(entry.getValue()).append("\r\n");
+        }
+        return sb.toString();
+    }
+
+}

--- a/src/main/java/webserver/http/common/HttpMethod.java
+++ b/src/main/java/webserver/http/common/HttpMethod.java
@@ -1,0 +1,23 @@
+package webserver.http.common;
+
+import webserver.http.exception.RequestParseException;
+
+public enum HttpMethod {
+
+    GET,
+    POST,
+    DELETE,
+    PUT,
+    PATCH;
+
+    public static HttpMethod fromString(String method) {
+        for (HttpMethod httpMethod : HttpMethod.values()) {
+            if (httpMethod.name().equalsIgnoreCase(method)) {
+                return httpMethod;
+            }
+        }
+
+        throw new RequestParseException("Invalid HTTP method: " + method);
+    }
+
+}

--- a/src/main/java/webserver/http/exception/HeaderNotFoundException.java
+++ b/src/main/java/webserver/http/exception/HeaderNotFoundException.java
@@ -1,0 +1,7 @@
+package webserver.http.exception;
+
+public class HeaderNotFoundException extends RuntimeException {
+    public HeaderNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/webserver/http/exception/HttpException.java
+++ b/src/main/java/webserver/http/exception/HttpException.java
@@ -1,0 +1,18 @@
+package webserver.http.exception;
+
+import webserver.http.response.HttpStatusCode;
+
+public class HttpException extends RuntimeException {
+
+    private final HttpStatusCode statusCode;
+
+    public HttpException(HttpStatusCode statusCode) {
+        super(statusCode.toString());
+        this.statusCode = statusCode;
+    }
+
+    public HttpStatusCode getStatusCode() {
+        return statusCode;
+    }
+
+}

--- a/src/main/java/webserver/http/request/ABNFRequestParser.java
+++ b/src/main/java/webserver/http/request/ABNFRequestParser.java
@@ -1,5 +1,6 @@
 package webserver.http.request;
 
+import webserver.http.common.HttpHeaders;
 import webserver.http.exception.RequestParseException;
 import webserver.util.Convertor;
 
@@ -88,7 +89,7 @@ public class ABNFRequestParser {
         RequestLine requestLine = parseRequestLine(requestLineStr);
 
         // 2. 헤더 파싱 (빈 줄(CRLF만 있는 줄)이 나오기 전까지)
-        Map<String, String> headers = new HashMap<>();
+        HttpHeaders headers = new HttpHeaders();
         String line;
         while ((line = readLineStrict()) != null) {
             if (line.isEmpty()) {
@@ -120,7 +121,7 @@ public class ABNFRequestParser {
         return new RequestLine(line);
     }
 
-    private void parseHeaderLine(String line, Map<String, String> headers) throws IOException {
+    private void parseHeaderLine(String line, HttpHeaders headers) throws IOException {
         Matcher m = HEADER_PATTERN.matcher(line);
         if (!m.matches()) {
             throw new RequestParseException("Invalid header field: " + line);
@@ -128,7 +129,7 @@ public class ABNFRequestParser {
 
         String fieldName = m.group(0);
         String fieldValue = m.group(1);
-        headers.put(fieldName, fieldValue);
+        headers.add(fieldName, fieldValue);
     }
 
     private String parseBody(String contentLengthStr) throws IOException {

--- a/src/main/java/webserver/http/request/ABNFRequestParser.java
+++ b/src/main/java/webserver/http/request/ABNFRequestParser.java
@@ -1,0 +1,199 @@
+package webserver.http.request;
+
+import webserver.http.exception.RequestParseException;
+import webserver.util.Convertor;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ABNFRequestParser {
+
+    /**
+     * ABNF
+     * Request-Line = Method SP Request-Target SP HTTP-Version CRLF
+     * method: token (RFC 7230 tchar: !, #, $, %, &, ', *, +, -, ., ^, _, `, |, ~, DIGIT, ALPHA)
+     * request-target: 공백이 아닌 문자열(\S+)
+     * http-version: "HTTP/" DIGIT "." DIGIT
+     */
+    private static final Pattern REQUEST_LINE_PATTERN = Pattern.compile(
+            "^(?<method>[!#$%&'*+\\-.^_`|~0-9A-Za-z]+) (?<requestTarget>\\S+) (?<httpVersion>HTTP/\\d\\.\\d)$"
+    );
+
+    /**
+     * ABNF
+     * header-field = field-name ":" OWS field-value OWS
+     * field-name = token
+     * field-value = *( field-content / obs-fold )
+     */
+    private static final Pattern HEADER_PATTERN = Pattern.compile(
+            "^(?<fieldName>[!#$%&'*+\\-.^_`|~0-9A-Za-z]+):[ \\t]*(?<fieldValue>.*?)[ \\t]*$"
+    );
+    private static final char CR = '\r';
+    private static final char LF = '\n';
+    private static final int BUFFER_SIZE = 1024;
+    private static final String CONTENT_LENGTH = "Content-Length";
+    private static final String TRANSFER_ENCODING = "Transfer-Encoding";
+    private static final String CHUNKED = "chunked";
+
+    private final BufferedReader reader;
+
+    public ABNFRequestParser(BufferedReader reader) {
+        this.reader = reader;
+    }
+
+    /**
+     * CRLF (CR+LF)를 엄격하게 확인하면서 한 줄씩 읽습니다.
+     *
+     * @throws IOException CRLF가 아닌 경우 예외를 발생
+     */
+    private String readLineStrict() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        int c;
+        boolean seenCR = false;
+        while ((c = reader.read()) != -1) {
+            if (c == CR) {
+                seenCR = true;
+            } else if (c == LF) {
+                if (!seenCR) {
+                    throw new RequestParseException("Invalid request line: " + sb);
+                }
+                return sb.toString();
+            } else {
+                if (seenCR) {
+                    // CR 이후에 LF가 오지 않은 경우
+                    throw new RequestParseException("Invalid request line: " + sb);
+                }
+                sb.append((char) c);
+            }
+        }
+        if (sb.isEmpty()) {
+            return null;
+        }
+        throw new RequestParseException("Invalid request line: " + sb);
+    }
+
+    /**
+     * HTTP 요청 전체를 파싱하여 HTTPRequest 객체를 반환합니다.
+     */
+    public HttpRequest parseRequest() throws IOException {
+        // 1. Request-Line 파싱 (CRLF 확인)
+        String requestLineStr = readLineStrict();
+        if (requestLineStr == null || requestLineStr.isEmpty()) {
+            throw new RequestParseException("Request line is empty");
+        }
+        RequestLine requestLine = parseRequestLine(requestLineStr);
+
+        // 2. 헤더 파싱 (빈 줄(CRLF만 있는 줄)이 나오기 전까지)
+        Map<String, String> headers = new HashMap<>();
+        String line;
+        while ((line = readLineStrict()) != null) {
+            if (line.isEmpty()) {
+                // 빈 줄: 헤더 영역의 종료를 의미 (CRLF만 존재)
+                break;
+            }
+            parseHeaderLine(line, headers);
+        }
+
+        // 3. 메시지 바디 파싱
+        String body = "";
+        if (headers.containsKey(TRANSFER_ENCODING) &&
+                headers.get(TRANSFER_ENCODING).trim().equalsIgnoreCase(CHUNKED)) {
+            // Chunked 인코딩일 경우
+            body = parseChunkedBody();
+        } else if (headers.containsKey(CONTENT_LENGTH)) {
+            body = parseBody(headers.get(CONTENT_LENGTH));
+        }
+
+        return new HttpRequest(requestLine, headers, body);
+    }
+
+    private RequestLine parseRequestLine(String line) throws IOException {
+        Matcher m = REQUEST_LINE_PATTERN.matcher(line);
+        if (!m.matches()) {
+            throw new RequestParseException("Invalid Request-Line: " + line);
+        }
+
+        return new RequestLine(line);
+    }
+
+    private void parseHeaderLine(String line, Map<String, String> headers) throws IOException {
+        Matcher m = HEADER_PATTERN.matcher(line);
+        if (!m.matches()) {
+            throw new RequestParseException("Invalid header field: " + line);
+        }
+
+        String fieldName = m.group(0);
+        String fieldValue = m.group(1);
+        headers.put(fieldName, fieldValue);
+    }
+
+    private String parseBody(String contentLengthStr) throws IOException {
+        long contentLength = Convertor.convertToLong(contentLengthStr);
+        StringBuilder bodyBuilder = new StringBuilder();
+        char[] buffer = new char[BUFFER_SIZE];
+        long remaining = contentLength;
+
+        while (remaining > 0) {
+            int toRead = (int) Math.min(buffer.length, remaining);
+            int read = reader.read(buffer, 0, toRead);
+            if (read == -1) {
+                throw new IOException("Expected " + contentLength + " bytes, but stream ended early");
+            }
+            bodyBuilder.append(buffer, 0, read);
+            remaining -= read;
+        }
+
+        return bodyBuilder.toString();
+    }
+
+    /**
+     * chunk          = chunk-size [ chunk-ext ] CRLF
+     * chunk-data CRLF
+     * chunk-size     = 1*HEX
+     */
+    private String parseChunkedBody() throws IOException {
+        StringBuilder bodyBuilder = new StringBuilder();
+        while (true) {
+            // 각 청크의 시작은 청크 사이즈를 나타내는 라인입니다.
+            String chunkSizeLine = readLineStrict();
+            if (chunkSizeLine == null) {
+                throw new RequestParseException("Unexpected end of stream while reading chunk size");
+            }
+            // 청크 사이즈 라인에 확장자(Chunk Extensions)가 있을 수 있으므로 ';' 앞까지 읽습니다.
+            int semicolonIndex = chunkSizeLine.indexOf(';');
+            String hexSizeStr = (semicolonIndex != -1) ? chunkSizeLine.substring(0, semicolonIndex) : chunkSizeLine;
+            int chunkSize = Convertor.convertToIntByHex(hexSizeStr);
+            if (chunkSize == 0) {
+                // trailer 헤더를 무시하고, 빈 줄(CRLF)만 확인
+                String trailerLine = readLineStrict();
+                if (trailerLine == null) {
+                    throw new RequestParseException("Expected CRLF after last chunk");
+                }
+
+                break;
+            }
+            // 청크 데이터 읽기
+            char[] chunkData = new char[chunkSize];
+            int totalRead = 0;
+            while (totalRead < chunkSize) {
+                int read = reader.read(chunkData, totalRead, chunkSize - totalRead);
+                if (read == -1) {
+                    throw new IOException("Unexpected end of stream while reading chunk data");
+                }
+                totalRead += read;
+            }
+            bodyBuilder.append(chunkData);
+            // 청크 데이터 뒤에는 반드시 CRLF
+            String crlf = readLineStrict();
+            if (crlf == null || !crlf.isEmpty()) {
+                throw new RequestParseException("Expected CRLF after chunk data");
+            }
+        }
+        return bodyBuilder.toString();
+    }
+
+}

--- a/src/main/java/webserver/http/request/ABNFRequestParser.java
+++ b/src/main/java/webserver/http/request/ABNFRequestParser.java
@@ -6,8 +6,6 @@ import webserver.util.Convertor;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -39,6 +37,8 @@ public class ABNFRequestParser {
     private static final String CONTENT_LENGTH = "Content-Length";
     private static final String TRANSFER_ENCODING = "Transfer-Encoding";
     private static final String CHUNKED = "chunked";
+    private static final String FILD_NAME = "fieldName";
+    private static final String FIELD_VALUE = "fieldValue";
 
     private final BufferedReader reader;
 
@@ -112,7 +112,7 @@ public class ABNFRequestParser {
         return new HttpRequest(requestLine, headers, body);
     }
 
-    private RequestLine parseRequestLine(String line) throws IOException {
+    private RequestLine parseRequestLine(String line) {
         Matcher m = REQUEST_LINE_PATTERN.matcher(line);
         if (!m.matches()) {
             throw new RequestParseException("Invalid Request-Line: " + line);
@@ -121,14 +121,14 @@ public class ABNFRequestParser {
         return new RequestLine(line);
     }
 
-    private void parseHeaderLine(String line, HttpHeaders headers) throws IOException {
+    private void parseHeaderLine(String line, HttpHeaders headers) {
         Matcher m = HEADER_PATTERN.matcher(line);
         if (!m.matches()) {
             throw new RequestParseException("Invalid header field: " + line);
         }
 
-        String fieldName = m.group(0);
-        String fieldValue = m.group(1);
+        String fieldName = m.group(FILD_NAME);
+        String fieldValue = m.group(FIELD_VALUE);
         headers.add(fieldName, fieldValue);
     }
 

--- a/src/main/java/webserver/http/request/HttpRequest.java
+++ b/src/main/java/webserver/http/request/HttpRequest.java
@@ -1,4 +1,4 @@
-package webserver.http;
+package webserver.http.request;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/main/java/webserver/http/request/HttpRequest.java
+++ b/src/main/java/webserver/http/request/HttpRequest.java
@@ -1,16 +1,16 @@
 package webserver.http.request;
 
-import java.util.Map;
+import webserver.http.common.HttpHeaders;
 
 import static webserver.http.common.HttpConstants.DOT;
 
 public class HttpRequest {
 
     private final RequestLine requestLine;
-    private final Map<String, String> headers;
+    private final HttpHeaders headers;
     private final String body;
 
-    public HttpRequest(RequestLine requestLine, Map<String, String> headers, String body) {
+    public HttpRequest(RequestLine requestLine, HttpHeaders headers, String body) {
         this.requestLine = requestLine;
         this.headers = headers;
         this.body = body;
@@ -24,7 +24,7 @@ public class HttpRequest {
         return requestLine;
     }
 
-    public Map<String, String> getHeaders() {
+    public HttpHeaders getHeaders() {
         return headers;
     }
 
@@ -34,14 +34,8 @@ public class HttpRequest {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(requestLine).append("\n");
-        for (Map.Entry<String, String> entry : headers.entrySet()) {
-            sb.append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
-        }
-        sb.append("\n").append(body);
 
-        return sb.toString();
+        return requestLine + "\n" + headers + body;
     }
 
 }

--- a/src/main/java/webserver/http/request/HttpRequest.java
+++ b/src/main/java/webserver/http/request/HttpRequest.java
@@ -8,10 +8,10 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-public class HttpRequest {
+import static webserver.http.common.HttpConstants.COLON;
+import static webserver.http.common.HttpConstants.DOT;
 
-    private static final String DOT = ".";
-    private static final String COLON = ":";
+public class HttpRequest {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpRequest.class);
     private final RequestLine requestLine;

--- a/src/main/java/webserver/http/request/HttpRequest.java
+++ b/src/main/java/webserver/http/request/HttpRequest.java
@@ -1,8 +1,7 @@
 package webserver.http.request;
 
 import webserver.http.common.HttpHeaders;
-
-import static webserver.http.common.HttpConstants.DOT;
+import webserver.http.common.HttpMethod;
 
 public class HttpRequest {
 
@@ -16,12 +15,16 @@ public class HttpRequest {
         this.body = body;
     }
 
-    public boolean isResourceRequest() {
-        return requestLine.getPath().contains(DOT);
-    }
-
     public RequestLine getRequestLine() {
         return requestLine;
+    }
+
+    public String getPath() {
+        return requestLine.getPath();
+    }
+
+    public HttpMethod getMethod() {
+        return requestLine.getMethod();
     }
 
     public HttpHeaders getHeaders() {

--- a/src/main/java/webserver/http/request/HttpRequest.java
+++ b/src/main/java/webserver/http/request/HttpRequest.java
@@ -35,7 +35,7 @@ public class HttpRequest {
         }
     }
 
-    public boolean isResource() {
+    public boolean isResourceRequest() {
         return requestLine.getPath().contains(DOT);
     }
 

--- a/src/main/java/webserver/http/request/HttpRequest.java
+++ b/src/main/java/webserver/http/request/HttpRequest.java
@@ -10,6 +10,9 @@ import java.util.Map;
 
 public class HttpRequest {
 
+    private static final String DOT = ".";
+    private static final String COLON = ":";
+
     private static final Logger logger = LoggerFactory.getLogger(HttpRequest.class);
     private final RequestLine requestLine;
     private final Map<String, String> headers;
@@ -23,7 +26,7 @@ public class HttpRequest {
 
         while ((line = reader.readLine()) != null && !line.isEmpty()) {
             logger.debug("Header line: {}", line);
-            int colonIndex = line.indexOf(":");
+            int colonIndex = line.indexOf(COLON);
             if (colonIndex != -1) {
                 String key = line.substring(0, colonIndex).trim();
                 String value = line.substring(colonIndex + 1).trim();
@@ -33,7 +36,7 @@ public class HttpRequest {
     }
 
     public boolean isResource() {
-        return requestLine.getPath().contains(".");
+        return requestLine.getPath().contains(DOT);
     }
 
     public RequestLine getRequestLine() {

--- a/src/main/java/webserver/http/request/HttpRequest.java
+++ b/src/main/java/webserver/http/request/HttpRequest.java
@@ -1,38 +1,19 @@
 package webserver.http.request;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
-import static webserver.http.common.HttpConstants.COLON;
 import static webserver.http.common.HttpConstants.DOT;
 
 public class HttpRequest {
 
-    private static final Logger logger = LoggerFactory.getLogger(HttpRequest.class);
     private final RequestLine requestLine;
     private final Map<String, String> headers;
+    private final String body;
 
-    public HttpRequest(BufferedReader reader) throws IOException {
-        headers = new HashMap<>();
-
-        String line = reader.readLine();
-        this.requestLine = new RequestLine(line);
-        logger.debug("Request line: {}", requestLine);
-
-        while ((line = reader.readLine()) != null && !line.isEmpty()) {
-            logger.debug("Header line: {}", line);
-            int colonIndex = line.indexOf(COLON);
-            if (colonIndex != -1) {
-                String key = line.substring(0, colonIndex).trim();
-                String value = line.substring(colonIndex + 1).trim();
-                headers.put(key, value);
-            }
-        }
+    public HttpRequest(RequestLine requestLine, Map<String, String> headers, String body) {
+        this.requestLine = requestLine;
+        this.headers = headers;
+        this.body = body;
     }
 
     public boolean isResourceRequest() {
@@ -45,6 +26,22 @@ public class HttpRequest {
 
     public Map<String, String> getHeaders() {
         return headers;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(requestLine).append("\n");
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            sb.append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
+        }
+        sb.append("\n").append(body);
+
+        return sb.toString();
     }
 
 }

--- a/src/main/java/webserver/http/request/HttpRequest.java
+++ b/src/main/java/webserver/http/request/HttpRequest.java
@@ -32,6 +32,10 @@ public class HttpRequest {
         }
     }
 
+    public boolean isResource() {
+        return requestLine.getPath().contains(".");
+    }
+
     public RequestLine getRequestLine() {
         return requestLine;
     }

--- a/src/main/java/webserver/http/request/HttpRequest.java
+++ b/src/main/java/webserver/http/request/HttpRequest.java
@@ -2,7 +2,6 @@ package webserver.http.request;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import webserver.http.exception.RequestParseException;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -12,30 +11,16 @@ import java.util.Map;
 public class HttpRequest {
 
     private static final Logger logger = LoggerFactory.getLogger(HttpRequest.class);
-    private final String method;
-    private final String uri;
-    private final String protocol;
+    private final RequestLine requestLine;
     private final Map<String, String> headers;
 
     public HttpRequest(BufferedReader reader) throws IOException {
         headers = new HashMap<>();
 
-        String requestLine = reader.readLine();
-        if (requestLine == null || requestLine.isEmpty()) {
-            throw new RequestParseException("Empty request line");
-        }
+        String line = reader.readLine();
+        this.requestLine = new RequestLine(line);
         logger.debug("Request line: {}", requestLine);
 
-        String[] tokens = requestLine.split(" ");
-        if (tokens.length < 3) {
-            throw new RequestParseException("Invalid request line: " + requestLine);
-        }
-
-        this.method = tokens[0];
-        this.uri = tokens[1];
-        this.protocol = tokens[2];
-
-        String line;
         while ((line = reader.readLine()) != null && !line.isEmpty()) {
             logger.debug("Header line: {}", line);
             int colonIndex = line.indexOf(":");
@@ -47,16 +32,8 @@ public class HttpRequest {
         }
     }
 
-    public String getMethod() {
-        return method;
-    }
-
-    public String getUri() {
-        return uri;
-    }
-
-    public String getProtocol() {
-        return protocol;
+    public RequestLine getRequestLine() {
+        return requestLine;
     }
 
     public Map<String, String> getHeaders() {

--- a/src/main/java/webserver/http/request/RequestLine.java
+++ b/src/main/java/webserver/http/request/RequestLine.java
@@ -104,7 +104,14 @@ public class RequestLine {
 
     @Override
     public String toString() {
-        return method.toString() + SPACE + path + AMPERSAND + queryString + SPACE + httpVersion;
+        StringBuilder sb = new StringBuilder();
+        sb.append(method).append(SPACE).append(path);
+        if (!queryString.isEmpty()) {
+            sb.append(QUERY_STRING_DELIMITER_WITHOUT_ESCAPE)
+                    .append(queryString);
+        }
+        sb.append(SPACE).append(httpVersion);
+        return sb.toString();
     }
 
 }

--- a/src/main/java/webserver/http/request/RequestLine.java
+++ b/src/main/java/webserver/http/request/RequestLine.java
@@ -3,6 +3,8 @@ package webserver.http.request;
 import webserver.http.common.HttpMethod;
 import webserver.http.exception.RequestParseException;
 
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -58,7 +60,8 @@ public class RequestLine {
             return queryParameters;
         }
 
-        String[] pairs = queryString.split(AMPERSAND);
+        String decodedQueryString = URLDecoder.decode(queryString, StandardCharsets.UTF_8);
+        String[] pairs = decodedQueryString.split(AMPERSAND);
         for (String pair : pairs) {
             String[] keyValue = pair.split(EQUAL);
             if (queryParameters.containsKey(keyValue[0])) {

--- a/src/main/java/webserver/http/request/RequestLine.java
+++ b/src/main/java/webserver/http/request/RequestLine.java
@@ -97,4 +97,9 @@ public class RequestLine {
         return queryString;
     }
 
+    @Override
+    public String toString() {
+        return method.toString() + SPACE + path + AMPERSAND + queryString + SPACE + httpVersion;
+    }
+
 }

--- a/src/main/java/webserver/http/request/RequestLine.java
+++ b/src/main/java/webserver/http/request/RequestLine.java
@@ -1,0 +1,100 @@
+package webserver.http.request;
+
+import webserver.http.common.HttpMethod;
+import webserver.http.exception.RequestParseException;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+public class RequestLine {
+
+    private static final Pattern HTTP_VERSION_PATTERN = Pattern.compile("HTTP/\\d\\.\\d");
+    private static final String QUERY_STRING_DELIMITER = "\\?";
+    private static final String QUERY_STRING_DELIMITER_WITHOUT_ESCAPE = "?";
+    private static final String AMPERSAND = "&";
+    private static final String EQUAL = "=";
+    private static final String SPACE = " ";
+    private static final String EMPTY = "";
+    private static final int EXPECTED_TOKEN_COUNT = 3;
+
+    private final HttpMethod method;
+    private final String path;
+    private final Map<String, String> queryString;
+    private final String httpVersion;
+
+    public RequestLine(String requestLine) {
+        String[] tokens = requestLine.split(SPACE);
+        validateRequestLine(tokens);
+        this.method = HttpMethod.fromString(tokens[0]);
+        this.httpVersion = tokens[2];
+
+        String[] uriParts = splitUri(tokens[1]);
+        this.path = uriParts[0];
+        this.queryString = parseQueryString(uriParts[1]);
+    }
+
+    private void validateRequestLine(String[] tokens) {
+        if (tokens.length != EXPECTED_TOKEN_COUNT) {
+            throw new RequestParseException("Invalid request line: " + String.join(" ", tokens));
+        }
+        if (!HTTP_VERSION_PATTERN.matcher(tokens[2]).matches()) {
+            throw new RequestParseException("Invalid HTTP version: " + tokens[2]);
+        }
+    }
+
+    private String[] splitUri(String uri) {
+        if (uri.contains(QUERY_STRING_DELIMITER_WITHOUT_ESCAPE)) {
+            return uri.split(QUERY_STRING_DELIMITER);
+        }
+
+        return new String[]{uri, EMPTY};
+    }
+
+    private Map<String, String> parseQueryString(String queryString) {
+        Map<String, String> queryParameters = new HashMap<>();
+        if (queryString.isEmpty()) {
+            return queryParameters;
+        }
+
+        String[] pairs = queryString.split(AMPERSAND);
+        for (String pair : pairs) {
+            String[] keyValue = pair.split(EQUAL);
+            if (queryParameters.containsKey(keyValue[0])) {
+                continue;
+            }
+            if (keyValue.length == 1) {
+                queryParameters.put(keyValue[0], EMPTY);
+                continue;
+            }
+            if (keyValue.length == 2) {
+                queryParameters.put(keyValue[0], keyValue[1]);
+                continue;
+            }
+            String joinedValue = java.util.Arrays
+                    .stream(keyValue, 1, keyValue.length)
+                    .collect(Collectors.joining(EQUAL));
+            queryParameters.put(keyValue[0], joinedValue);
+        }
+
+        return queryParameters;
+    }
+
+    public HttpMethod getMethod() {
+        return method;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getHttpVersion() {
+        return httpVersion;
+    }
+
+    public Map<String, String> getQueryString() {
+        return queryString;
+    }
+
+}

--- a/src/main/java/webserver/http/request/RequestLine.java
+++ b/src/main/java/webserver/http/request/RequestLine.java
@@ -62,17 +62,21 @@ public class RequestLine {
         String[] pairs = decodedQueryString.split(AMPERSAND);
         for (String pair : pairs) {
             String[] keyValue = pair.split(EQUALS);
+            // 이미 존재하는 키는 무시
             if (queryParameters.containsKey(keyValue[0])) {
                 continue;
             }
+            // 키는 존재하지만 값이 없는 경우 값은 빈 문자열
             if (keyValue.length == 1) {
                 queryParameters.put(keyValue[0], EMPTY);
                 continue;
             }
+            // 키와 값이 모두 존재하는 경우
             if (keyValue.length == 2) {
                 queryParameters.put(keyValue[0], keyValue[1]);
                 continue;
             }
+            // 키가 존재하고 값이 여러 개인 경우 가장 앞의 "=" 이후의 값은 모두 값으로 사용
             String joinedValue = java.util.Arrays
                     .stream(keyValue, 1, keyValue.length)
                     .collect(Collectors.joining(EQUALS));

--- a/src/main/java/webserver/http/request/RequestLine.java
+++ b/src/main/java/webserver/http/request/RequestLine.java
@@ -10,15 +10,13 @@ import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
+import static webserver.http.common.HttpConstants.*;
+
 public class RequestLine {
 
     private static final Pattern HTTP_VERSION_PATTERN = Pattern.compile("HTTP/\\d\\.\\d");
     private static final String QUERY_STRING_DELIMITER = "\\?";
     private static final String QUERY_STRING_DELIMITER_WITHOUT_ESCAPE = "?";
-    private static final String AMPERSAND = "&";
-    private static final String EQUAL = "=";
-    private static final String SPACE = " ";
-    private static final String EMPTY = "";
     private static final int EXPECTED_TOKEN_COUNT = 3;
 
     private final HttpMethod method;
@@ -39,7 +37,7 @@ public class RequestLine {
 
     private void validateRequestLine(String[] tokens) {
         if (tokens.length != EXPECTED_TOKEN_COUNT) {
-            throw new RequestParseException("Invalid request line: " + String.join(" ", tokens));
+            throw new RequestParseException("Invalid request line: " + String.join(SPACE, tokens));
         }
         if (!HTTP_VERSION_PATTERN.matcher(tokens[2]).matches()) {
             throw new RequestParseException("Invalid HTTP version: " + tokens[2]);
@@ -63,7 +61,7 @@ public class RequestLine {
         String decodedQueryString = URLDecoder.decode(queryString, StandardCharsets.UTF_8);
         String[] pairs = decodedQueryString.split(AMPERSAND);
         for (String pair : pairs) {
-            String[] keyValue = pair.split(EQUAL);
+            String[] keyValue = pair.split(EQUALS);
             if (queryParameters.containsKey(keyValue[0])) {
                 continue;
             }
@@ -77,7 +75,7 @@ public class RequestLine {
             }
             String joinedValue = java.util.Arrays
                     .stream(keyValue, 1, keyValue.length)
-                    .collect(Collectors.joining(EQUAL));
+                    .collect(Collectors.joining(EQUALS));
             queryParameters.put(keyValue[0], joinedValue);
         }
 

--- a/src/main/java/webserver/http/response/HttpResponse.java
+++ b/src/main/java/webserver/http/response/HttpResponse.java
@@ -1,4 +1,4 @@
-package webserver.http;
+package webserver.http.response;
 
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/src/main/java/webserver/http/response/HttpResponse.java
+++ b/src/main/java/webserver/http/response/HttpResponse.java
@@ -1,33 +1,30 @@
 package webserver.http.response;
 
-import webserver.http.common.ContentType;
+import webserver.http.common.HttpHeaders;
 
-import java.io.DataOutputStream;
-import java.io.IOException;
-import java.util.logging.Logger;
+import java.util.Arrays;
 
-import static webserver.http.common.HttpConstants.*;
+import static webserver.http.common.HttpConstants.CR;
+import static webserver.http.common.HttpConstants.LF;
 
 public class HttpResponse {
 
-    private static final Logger logger = Logger.getLogger(HttpResponse.class.getName());
-    private final DataOutputStream dos;
+    private final StatusLine statusLine;
+    private final HttpHeaders headers;
+    private final byte[] body;
 
-    public HttpResponse(DataOutputStream dos) {
-        this.dos = dos;
+    public HttpResponse(StatusLine statusLine, HttpHeaders headers, byte[] body) {
+        this.statusLine = statusLine;
+        this.headers = headers;
+        this.body = body;
     }
 
-    public void sendResponse(HttpStatusCode httpStatusCode, ContentType contentType, byte[] body) {
-        try {
-            dos.writeBytes("HTTP/1.1 " + httpStatusCode + CR + LF);
-            dos.writeBytes("Content-Type: " + contentType.getMimeType() + CR + LF);
-            dos.writeBytes("Content-Length: " + body.length + CR + LF);
-            dos.writeBytes(CR + LF);
-            dos.write(body, 0, body.length);
-            dos.flush();
-        } catch (IOException e) {
-            logger.severe("Error sending response: " + e.getMessage());
-        }
+    @Override
+    public String toString() {
+        return statusLine + CR + LF +
+                headers + CR + LF +
+                CR + LF +
+                Arrays.toString(body) + CR + LF;
     }
 
 }

--- a/src/main/java/webserver/http/response/HttpResponse.java
+++ b/src/main/java/webserver/http/response/HttpResponse.java
@@ -4,6 +4,8 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.logging.Logger;
 
+import static webserver.http.common.HttpConstants.*;
+
 public class HttpResponse {
 
     private static final Logger logger = Logger.getLogger(HttpResponse.class.getName());
@@ -15,10 +17,10 @@ public class HttpResponse {
 
     public void sendResponse(int statusCode, String statusText, String contentType, byte[] body) {
         try {
-            dos.writeBytes("HTTP/1.1 " + statusCode + " " + statusText + "\r\n");
-            dos.writeBytes("Content-Type: " + contentType + "\r\n");
-            dos.writeBytes("Content-Length: " + body.length + "\r\n");
-            dos.writeBytes("\r\n");
+            dos.writeBytes("HTTP/1.1 " + statusCode + SPACE + statusText + CR + LF);
+            dos.writeBytes("Content-Type: " + contentType + CR + LF);
+            dos.writeBytes("Content-Length: " + body.length + CR + LF);
+            dos.writeBytes(CR + LF);
             dos.write(body, 0, body.length);
             dos.flush();
         } catch (IOException e) {

--- a/src/main/java/webserver/http/response/HttpResponse.java
+++ b/src/main/java/webserver/http/response/HttpResponse.java
@@ -1,5 +1,7 @@
 package webserver.http.response;
 
+import webserver.http.common.ContentType;
+
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.logging.Logger;
@@ -15,10 +17,10 @@ public class HttpResponse {
         this.dos = dos;
     }
 
-    public void sendResponse(HttpStatusCode httpStatusCode, String contentType, byte[] body) {
+    public void sendResponse(HttpStatusCode httpStatusCode, ContentType contentType, byte[] body) {
         try {
             dos.writeBytes("HTTP/1.1 " + httpStatusCode.getStatusCode() + SPACE + httpStatusCode.getReasonPhrase() + CR + LF);
-            dos.writeBytes("Content-Type: " + contentType + CR + LF);
+            dos.writeBytes("Content-Type: " + contentType.getMimeType() + CR + LF);
             dos.writeBytes("Content-Length: " + body.length + CR + LF);
             dos.writeBytes(CR + LF);
             dos.write(body, 0, body.length);

--- a/src/main/java/webserver/http/response/HttpResponse.java
+++ b/src/main/java/webserver/http/response/HttpResponse.java
@@ -15,9 +15,9 @@ public class HttpResponse {
         this.dos = dos;
     }
 
-    public void sendResponse(int statusCode, String statusText, String contentType, byte[] body) {
+    public void sendResponse(HttpStatusCode httpStatusCode, String contentType, byte[] body) {
         try {
-            dos.writeBytes("HTTP/1.1 " + statusCode + SPACE + statusText + CR + LF);
+            dos.writeBytes("HTTP/1.1 " + httpStatusCode.getStatusCode() + SPACE + httpStatusCode.getReasonPhrase() + CR + LF);
             dos.writeBytes("Content-Type: " + contentType + CR + LF);
             dos.writeBytes("Content-Length: " + body.length + CR + LF);
             dos.writeBytes(CR + LF);
@@ -26,21 +26,6 @@ public class HttpResponse {
         } catch (IOException e) {
             logger.severe("Error sending response: " + e.getMessage());
         }
-    }
-
-    public void send400() {
-        String msg = "<h1>400 Bad Request</h1>";
-        sendResponse(400, "Bad Request", "text/html;charset=utf-8", msg.getBytes());
-    }
-
-    public void send404() {
-        String msg = "<h1>404 Not Found</h1>";
-        sendResponse(404, "Not Found", "text/html;charset=utf-8", msg.getBytes());
-    }
-
-    public void send415() {
-        String msg = "<h1>415 Unsupported Media Type</h1>";
-        sendResponse(415, "Unsupported Media Type", "text/html;charset=utf-8", msg.getBytes());
     }
 
 }

--- a/src/main/java/webserver/http/response/HttpResponse.java
+++ b/src/main/java/webserver/http/response/HttpResponse.java
@@ -19,7 +19,7 @@ public class HttpResponse {
 
     public void sendResponse(HttpStatusCode httpStatusCode, ContentType contentType, byte[] body) {
         try {
-            dos.writeBytes("HTTP/1.1 " + httpStatusCode.getStatusCode() + SPACE + httpStatusCode.getReasonPhrase() + CR + LF);
+            dos.writeBytes("HTTP/1.1 " + httpStatusCode + CR + LF);
             dos.writeBytes("Content-Type: " + contentType.getMimeType() + CR + LF);
             dos.writeBytes("Content-Length: " + body.length + CR + LF);
             dos.writeBytes(CR + LF);

--- a/src/main/java/webserver/http/response/HttpResponse.java
+++ b/src/main/java/webserver/http/response/HttpResponse.java
@@ -2,7 +2,7 @@ package webserver.http.response;
 
 import webserver.http.common.HttpHeaders;
 
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
 
 import static webserver.http.common.HttpConstants.CR;
 import static webserver.http.common.HttpConstants.LF;
@@ -19,12 +19,15 @@ public class HttpResponse {
         this.body = body;
     }
 
-    @Override
-    public String toString() {
-        return statusLine + CR + LF +
-                headers + CR + LF +
-                CR + LF +
-                Arrays.toString(body) + CR + LF;
+    public byte[] getBytes() {
+        String headerPart = statusLine + CR + LF +
+                headers + CR + LF;
+        byte[] headerBytes = headerPart.getBytes(StandardCharsets.UTF_8);
+        byte[] responseBytes = new byte[headerBytes.length + body.length];
+        System.arraycopy(headerBytes, 0, responseBytes, 0, headerBytes.length);
+        System.arraycopy(body, 0, responseBytes, headerBytes.length, body.length);
+
+        return responseBytes;
     }
 
 }

--- a/src/main/java/webserver/http/response/HttpStatusCode.java
+++ b/src/main/java/webserver/http/response/HttpStatusCode.java
@@ -1,5 +1,7 @@
 package webserver.http.response;
 
+import static webserver.http.common.HttpConstants.SPACE;
+
 public enum HttpStatusCode {
 
     OK(200, "OK"),
@@ -30,6 +32,11 @@ public enum HttpStatusCode {
 
     public String getReasonPhrase() {
         return reasonPhrase;
+    }
+
+    @Override
+    public String toString() {
+        return statusCode + SPACE + reasonPhrase;
     }
 
 }

--- a/src/main/java/webserver/http/response/HttpStatusCode.java
+++ b/src/main/java/webserver/http/response/HttpStatusCode.java
@@ -1,0 +1,35 @@
+package webserver.http.response;
+
+public enum HttpStatusCode {
+
+    OK(200, "OK"),
+    CREATED(201, "Created"),
+    NO_CONTENT(204, "No Content"),
+    BAD_REQUEST(400, "Bad Request"),
+    UNAUTHORIZED(401, "Unauthorized"),
+    FORBIDDEN(403, "Forbidden"),
+    NOT_FOUND(404, "Not Found"),
+    METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
+    REQUEST_TIMEOUT(408, "Request Timeout"),
+    CONFLICT(409, "Conflict"),
+    UNSUPPORTED_MEDIA_TYPE(415, "Unsupported Media Type"),
+    INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
+    HTTP_VERSION_NOT_SUPPORTED(505, "HTTP Version Not Supported");
+
+    private final int statusCode;
+    private final String reasonPhrase;
+
+    HttpStatusCode(int statusCode, String reasonPhrase) {
+        this.statusCode = statusCode;
+        this.reasonPhrase = reasonPhrase;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getReasonPhrase() {
+        return reasonPhrase;
+    }
+
+}

--- a/src/main/java/webserver/http/response/StatusLine.java
+++ b/src/main/java/webserver/http/response/StatusLine.java
@@ -1,0 +1,31 @@
+package webserver.http.response;
+
+import static webserver.http.common.HttpConstants.SPACE;
+
+public class StatusLine {
+
+    private static final String httpVersion = "HTTP/1.1";
+    private HttpStatusCode httpStatusCode;
+
+    public StatusLine(HttpStatusCode httpStatusCode) {
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    public String getHttpVersion() {
+        return httpVersion;
+    }
+
+    public HttpStatusCode getHttpStatusCode() {
+        return httpStatusCode;
+    }
+
+    public void setHttpStatusCode(HttpStatusCode httpStatusCode) {
+        this.httpStatusCode = httpStatusCode;
+    }
+
+    @Override
+    public String toString() {
+        return httpVersion + SPACE + httpStatusCode;
+    }
+
+}

--- a/src/main/java/webserver/http/response/StatusLine.java
+++ b/src/main/java/webserver/http/response/StatusLine.java
@@ -5,21 +5,9 @@ import static webserver.http.common.HttpConstants.SPACE;
 public class StatusLine {
 
     private static final String httpVersion = "HTTP/1.1";
-    private HttpStatusCode httpStatusCode;
+    private final HttpStatusCode httpStatusCode;
 
     public StatusLine(HttpStatusCode httpStatusCode) {
-        this.httpStatusCode = httpStatusCode;
-    }
-
-    public String getHttpVersion() {
-        return httpVersion;
-    }
-
-    public HttpStatusCode getHttpStatusCode() {
-        return httpStatusCode;
-    }
-
-    public void setHttpStatusCode(HttpStatusCode httpStatusCode) {
         this.httpStatusCode = httpStatusCode;
     }
 

--- a/src/main/java/webserver/mapper/HandlerMapper.java
+++ b/src/main/java/webserver/mapper/HandlerMapper.java
@@ -1,7 +1,7 @@
 package webserver.mapper;
 
-import annotation.RequestMapping;
-import controller.Handler;
+import webserver.annotation.RequestMapping;
+import handler.Handler;
 import webserver.http.common.HttpMethod;
 import webserver.http.exception.HttpException;
 import webserver.resolver.DynamicHandler;

--- a/src/main/java/webserver/mapper/HandlerMapper.java
+++ b/src/main/java/webserver/mapper/HandlerMapper.java
@@ -5,7 +5,10 @@ import handler.Handler;
 import webserver.http.common.HttpMethod;
 import webserver.http.exception.HttpException;
 import webserver.resolver.DynamicHandler;
+import webserver.resolver.ResolveResponse;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -17,6 +20,8 @@ import static webserver.http.response.HttpStatusCode.INTERNAL_SERVER_ERROR;
 public class HandlerMapper {
 
     private static final HandlerMapper instance = new HandlerMapper();
+    // 잦은 리플렉션 사용으로 성능 저하를 방지하기 위해 MethodHandles.Lookup을 사용
+    private final MethodHandles.Lookup lookup = MethodHandles.lookup();
     private final Map<String, DynamicHandler> mappings;
 
     private HandlerMapper() {
@@ -34,20 +39,35 @@ public class HandlerMapper {
         Method[] methods = controller.getClass().getDeclaredMethods();
         for (Method method : methods) {
             if (method.isAnnotationPresent(RequestMapping.class)) {
-                RequestMapping mapping = method.getAnnotation(RequestMapping.class);
-                String key = mapping.method() + SPACE + mapping.path();
-                DynamicHandler handler = (request) -> {
-                    try {
-                        return (webserver.resolver.ResolveResponse<?>) method.invoke(controller, request);
-                    } catch (InvocationTargetException e) {
-                        throw (HttpException) e.getCause();
-                    } catch (IllegalAccessException e) {
-                        throw new HttpException(INTERNAL_SERVER_ERROR);
-                    }
-                };
-                mappings.put(key, handler);
+                registerMapping(controller, method);
             }
         }
+    }
+
+    private void registerMapping(Object controller, Method method) {
+        RequestMapping mapping = method.getAnnotation(RequestMapping.class);
+        String key = mapping.method() + SPACE + mapping.path();
+
+        try {
+            MethodHandle methodHandle = lookup.unreflect(method).bindTo(controller);
+            DynamicHandler handler = createDynamicHandler(methodHandle);
+            mappings.put(key, handler);
+        } catch (IllegalAccessException e) {
+            throw new HttpException(INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private DynamicHandler createDynamicHandler(MethodHandle methodHandle) {
+        return (request) -> {
+            try {
+                return (ResolveResponse<?>) methodHandle.invoke(request);
+            } catch (Throwable t) {
+                if (t instanceof InvocationTargetException) {
+                    throw (HttpException) t.getCause();
+                }
+                throw new HttpException(INTERNAL_SERVER_ERROR);
+            }
+        };
     }
 
     public DynamicHandler getHandler(HttpMethod method, String path) {

--- a/src/main/java/webserver/mapper/HandlerMapper.java
+++ b/src/main/java/webserver/mapper/HandlerMapper.java
@@ -62,9 +62,10 @@ public class HandlerMapper {
             try {
                 return (ResolveResponse<?>) methodHandle.invoke(request);
             } catch (Throwable t) {
-                if (t instanceof InvocationTargetException) {
-                    throw (HttpException) t.getCause();
+                if (t instanceof HttpException) {
+                    throw (HttpException) t;
                 }
+
                 throw new HttpException(INTERNAL_SERVER_ERROR);
             }
         };

--- a/src/main/java/webserver/mapper/HandlerMapper.java
+++ b/src/main/java/webserver/mapper/HandlerMapper.java
@@ -1,0 +1,57 @@
+package webserver.mapper;
+
+import annotation.RequestMapping;
+import controller.Handler;
+import webserver.http.common.HttpMethod;
+import webserver.http.exception.HttpException;
+import webserver.resolver.DynamicHandler;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import static webserver.http.common.HttpConstants.SPACE;
+import static webserver.http.response.HttpStatusCode.INTERNAL_SERVER_ERROR;
+
+public class HandlerMapper {
+
+    private static final HandlerMapper instance = new HandlerMapper();
+    private final Map<String, DynamicHandler> mappings;
+
+    private HandlerMapper() {
+        this.mappings = new HashMap<>();
+
+        // 컨트롤러 등록
+        registerController(Handler.getInstance());
+    }
+
+    public static HandlerMapper getInstance() {
+        return instance;
+    }
+
+    private void registerController(Object controller) {
+        Method[] methods = controller.getClass().getDeclaredMethods();
+        for (Method method : methods) {
+            if (method.isAnnotationPresent(RequestMapping.class)) {
+                RequestMapping mapping = method.getAnnotation(RequestMapping.class);
+                String key = mapping.method() + SPACE + mapping.path();
+                DynamicHandler handler = (request) -> {
+                    try {
+                        return (webserver.resolver.ResolveResponse<?>) method.invoke(controller, request);
+                    } catch (InvocationTargetException e) {
+                        throw (HttpException) e.getCause();
+                    } catch (IllegalAccessException e) {
+                        throw new HttpException(INTERNAL_SERVER_ERROR);
+                    }
+                };
+                mappings.put(key, handler);
+            }
+        }
+    }
+
+    public DynamicHandler getHandler(HttpMethod method, String path) {
+        return mappings.get(method + SPACE + path);
+    }
+
+}

--- a/src/main/java/webserver/resolver/DynamicHandler.java
+++ b/src/main/java/webserver/resolver/DynamicHandler.java
@@ -1,0 +1,8 @@
+package webserver.resolver;
+
+import webserver.http.request.HttpRequest;
+
+@FunctionalInterface
+public interface DynamicHandler {
+    ResolveResponse<?> handle(HttpRequest request);
+}

--- a/src/main/java/webserver/resolver/DynamicResolver.java
+++ b/src/main/java/webserver/resolver/DynamicResolver.java
@@ -7,7 +7,7 @@ import webserver.http.common.HttpMethod;
 import webserver.http.request.HttpRequest;
 import webserver.http.response.HttpResponse;
 
-public class DynamicResolver {
+public class DynamicResolver implements Resolver {
 
     private static final Logger logger = LoggerFactory.getLogger(DynamicResolver.class);
     private static final Controller controller = new Controller();
@@ -19,6 +19,7 @@ public class DynamicResolver {
         this.response = response;
     }
 
+    @Override
     public void resolve() {
         HttpMethod method = request.getRequestLine().getMethod();
         String path = request.getRequestLine().getPath();

--- a/src/main/java/webserver/resolver/DynamicResolver.java
+++ b/src/main/java/webserver/resolver/DynamicResolver.java
@@ -1,36 +1,24 @@
 package webserver.resolver;
 
-import controller.Handler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import webserver.http.common.HttpMethod;
-import webserver.http.exception.HttpException;
 import webserver.http.request.HttpRequest;
-
-import static webserver.http.response.HttpStatusCode.METHOD_NOT_ALLOWED;
 
 public class DynamicResolver implements Resolver {
 
     private static final Logger logger = LoggerFactory.getLogger(DynamicResolver.class);
-    private final Handler handler;
     private final HttpRequest request;
+    private final DynamicHandler dynamicHandler;
 
-    public DynamicResolver(HttpRequest request) {
+    public DynamicResolver(HttpRequest request, DynamicHandler handler) {
         this.request = request;
-        this.handler = Handler.getInstance();
+        this.dynamicHandler = handler;
     }
 
     @Override
     public ResolveResponse<?> resolve() {
-        HttpMethod method = request.getRequestLine().getMethod();
-        String path = request.getRequestLine().getPath();
-
-        if (method.equals(HttpMethod.GET) && path.equals("/create")) {
-            return handler.getCreate(request);
-        } else {
-            logger.error("Unsupported method or path: {} {}", method, path);
-            throw new HttpException(METHOD_NOT_ALLOWED);
-        }
+        logger.debug("DynamicResolver");
+        return dynamicHandler.handle(request);
     }
 
 }

--- a/src/main/java/webserver/resolver/DynamicResolver.java
+++ b/src/main/java/webserver/resolver/DynamicResolver.java
@@ -3,6 +3,7 @@ package webserver.resolver;
 import controller.Controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.http.common.ContentType;
 import webserver.http.common.HttpMethod;
 import webserver.http.request.HttpRequest;
 import webserver.http.response.HttpResponse;
@@ -29,7 +30,7 @@ public class DynamicResolver implements Resolver {
             controller.getCreate(request, response);
         } else {
             logger.error("Unsupported method or path: {} {}", method, path);
-            response.sendResponse(HttpStatusCode.BAD_REQUEST, "application/json", "{\"error\": \"Unsupported method or path\"}".getBytes());
+            response.sendResponse(HttpStatusCode.BAD_REQUEST, ContentType.JSON, "{\"error\": \"Unsupported method or path\"}".getBytes());
         }
     }
 

--- a/src/main/java/webserver/resolver/DynamicResolver.java
+++ b/src/main/java/webserver/resolver/DynamicResolver.java
@@ -1,0 +1,33 @@
+package webserver.resolver;
+
+import controller.Controller;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import webserver.http.common.HttpMethod;
+import webserver.http.request.HttpRequest;
+import webserver.http.response.HttpResponse;
+
+public class DynamicResolver {
+
+    private static final Logger logger = LoggerFactory.getLogger(DynamicResolver.class);
+    private static final Controller controller = new Controller();
+    private final HttpRequest request;
+    private final HttpResponse response;
+
+    public DynamicResolver(HttpRequest request, HttpResponse response) {
+        this.request = request;
+        this.response = response;
+    }
+
+    public void resolve() {
+        HttpMethod method = request.getRequestLine().getMethod();
+        String path = request.getRequestLine().getPath();
+
+        if (method.equals(HttpMethod.GET) && path.equals("/create")) {
+            controller.getCreate(request, response);
+        } else {
+            logger.error("Unsupported method or path: {} {}", method, path);
+        }
+    }
+
+}

--- a/src/main/java/webserver/resolver/DynamicResolver.java
+++ b/src/main/java/webserver/resolver/DynamicResolver.java
@@ -3,11 +3,11 @@ package webserver.resolver;
 import controller.Controller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import webserver.http.common.ContentType;
 import webserver.http.common.HttpMethod;
+import webserver.http.exception.HttpException;
 import webserver.http.request.HttpRequest;
-import webserver.http.response.HttpResponse;
-import webserver.http.response.HttpStatusCode;
+
+import static webserver.http.response.HttpStatusCode.METHOD_NOT_ALLOWED;
 
 public class DynamicResolver implements Resolver {
 
@@ -21,15 +21,15 @@ public class DynamicResolver implements Resolver {
     }
 
     @Override
-    public HttpResponse resolve() {
+    public ResolveResponse<?> resolve() {
         HttpMethod method = request.getRequestLine().getMethod();
         String path = request.getRequestLine().getPath();
 
         if (method.equals(HttpMethod.GET) && path.equals("/create")) {
-            controller.getCreate(request);
+            return controller.getCreate(request);
         } else {
             logger.error("Unsupported method or path: {} {}", method, path);
-            response.sendResponse(HttpStatusCode.BAD_REQUEST, ContentType.HTML, "<h1>Bad Request</h1>".getBytes());
+            throw new HttpException(METHOD_NOT_ALLOWED);
         }
     }
 

--- a/src/main/java/webserver/resolver/DynamicResolver.java
+++ b/src/main/java/webserver/resolver/DynamicResolver.java
@@ -6,6 +6,7 @@ import org.slf4j.LoggerFactory;
 import webserver.http.common.HttpMethod;
 import webserver.http.request.HttpRequest;
 import webserver.http.response.HttpResponse;
+import webserver.http.response.HttpStatusCode;
 
 public class DynamicResolver implements Resolver {
 
@@ -28,7 +29,7 @@ public class DynamicResolver implements Resolver {
             controller.getCreate(request, response);
         } else {
             logger.error("Unsupported method or path: {} {}", method, path);
-            response.send400();
+            response.sendResponse(HttpStatusCode.BAD_REQUEST, "application/json", "{\"error\": \"Unsupported method or path\"}".getBytes());
         }
     }
 

--- a/src/main/java/webserver/resolver/DynamicResolver.java
+++ b/src/main/java/webserver/resolver/DynamicResolver.java
@@ -12,13 +12,14 @@ import webserver.http.response.HttpStatusCode;
 public class DynamicResolver implements Resolver {
 
     private static final Logger logger = LoggerFactory.getLogger(DynamicResolver.class);
-    private static final Controller controller = new Controller();
+    private final Controller controller;
     private final HttpRequest request;
     private final HttpResponse response;
 
     public DynamicResolver(HttpRequest request, HttpResponse response) {
         this.request = request;
         this.response = response;
+        this.controller = Controller.getInstance();
     }
 
     @Override

--- a/src/main/java/webserver/resolver/DynamicResolver.java
+++ b/src/main/java/webserver/resolver/DynamicResolver.java
@@ -31,7 +31,7 @@ public class DynamicResolver implements Resolver {
             controller.getCreate(request, response);
         } else {
             logger.error("Unsupported method or path: {} {}", method, path);
-            response.sendResponse(HttpStatusCode.BAD_REQUEST, ContentType.JSON, "{\"error\": \"Unsupported method or path\"}".getBytes());
+            response.sendResponse(HttpStatusCode.BAD_REQUEST, ContentType.HTML, "<h1>Bad Request</h1>".getBytes());
         }
     }
 

--- a/src/main/java/webserver/resolver/DynamicResolver.java
+++ b/src/main/java/webserver/resolver/DynamicResolver.java
@@ -28,6 +28,7 @@ public class DynamicResolver implements Resolver {
             controller.getCreate(request, response);
         } else {
             logger.error("Unsupported method or path: {} {}", method, path);
+            response.send400();
         }
     }
 

--- a/src/main/java/webserver/resolver/DynamicResolver.java
+++ b/src/main/java/webserver/resolver/DynamicResolver.java
@@ -14,21 +14,19 @@ public class DynamicResolver implements Resolver {
     private static final Logger logger = LoggerFactory.getLogger(DynamicResolver.class);
     private final Controller controller;
     private final HttpRequest request;
-    private final HttpResponse response;
 
-    public DynamicResolver(HttpRequest request, HttpResponse response) {
+    public DynamicResolver(HttpRequest request) {
         this.request = request;
-        this.response = response;
         this.controller = Controller.getInstance();
     }
 
     @Override
-    public void resolve() {
+    public HttpResponse resolve() {
         HttpMethod method = request.getRequestLine().getMethod();
         String path = request.getRequestLine().getPath();
 
         if (method.equals(HttpMethod.GET) && path.equals("/create")) {
-            controller.getCreate(request, response);
+            controller.getCreate(request);
         } else {
             logger.error("Unsupported method or path: {} {}", method, path);
             response.sendResponse(HttpStatusCode.BAD_REQUEST, ContentType.HTML, "<h1>Bad Request</h1>".getBytes());

--- a/src/main/java/webserver/resolver/DynamicResolver.java
+++ b/src/main/java/webserver/resolver/DynamicResolver.java
@@ -1,6 +1,6 @@
 package webserver.resolver;
 
-import controller.Controller;
+import controller.Handler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.http.common.HttpMethod;
@@ -12,12 +12,12 @@ import static webserver.http.response.HttpStatusCode.METHOD_NOT_ALLOWED;
 public class DynamicResolver implements Resolver {
 
     private static final Logger logger = LoggerFactory.getLogger(DynamicResolver.class);
-    private final Controller controller;
+    private final Handler handler;
     private final HttpRequest request;
 
     public DynamicResolver(HttpRequest request) {
         this.request = request;
-        this.controller = Controller.getInstance();
+        this.handler = Handler.getInstance();
     }
 
     @Override
@@ -26,7 +26,7 @@ public class DynamicResolver implements Resolver {
         String path = request.getRequestLine().getPath();
 
         if (method.equals(HttpMethod.GET) && path.equals("/create")) {
-            return controller.getCreate(request);
+            return handler.getCreate(request);
         } else {
             logger.error("Unsupported method or path: {} {}", method, path);
             throw new HttpException(METHOD_NOT_ALLOWED);

--- a/src/main/java/webserver/resolver/ResolveResponse.java
+++ b/src/main/java/webserver/resolver/ResolveResponse.java
@@ -1,14 +1,15 @@
 package webserver.resolver;
 
-import com.sun.net.httpserver.Headers;
 import webserver.http.common.ContentType;
 import webserver.http.common.HttpHeaders;
 import webserver.http.response.HttpStatusCode;
 
 import static webserver.http.common.ContentType.HTML;
-import static webserver.http.response.HttpStatusCode.*;
+import static webserver.http.common.ContentType.TEXT;
+import static webserver.http.response.HttpStatusCode.OK;
 
 public class ResolveResponse<T> {
+
     private final HttpStatusCode statusCode;
     private final HttpHeaders headers;
     private final T body;
@@ -33,33 +34,30 @@ public class ResolveResponse<T> {
 
     public static <T> ResolveResponse<T> ok(T body) {
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", HTML.getMimeType());
         headers.addContentType(HTML);
+
         return new ResolveResponse<>(OK, headers, body);
     }
 
-    public static <T> ResolveResponse<T> ok(HttpStatusCode statusCode, T body) {
+    public static <T> ResolveResponse<T> ok(ContentType contentType, T body) {
         HttpHeaders headers = new HttpHeaders();
-        headers.addContentType(HTML);
+        headers.addContentType(contentType);
+
+        return new ResolveResponse<>(OK, headers, body);
+    }
+
+    public static <T> ResolveResponse<T> status(HttpStatusCode statusCode, T body) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.addContentType(TEXT);
+
         return new ResolveResponse<>(statusCode, headers, body);
     }
 
-    public static <T> ResolveResponse<T> ok(T body, ContentType contentType) {
+    public static ResolveResponse<String> status(HttpStatusCode statusCode) {
         HttpHeaders headers = new HttpHeaders();
-        headers.addContentType(contentType);
-        return new ResolveResponse<>(OK, headers, body);
-    }
+        headers.addContentType(TEXT);
 
-    public static <T> ResolveResponse<T> badRequest(T body) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.addContentType(HTML);
-        return new ResolveResponse<>(BAD_REQUEST, headers, body);
-    }
-
-    public static <T> ResolveResponse<T> notFound(T body) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.addContentType(HTML);
-        return new ResolveResponse<>(NOT_FOUND, headers, body);
+        return new ResolveResponse<>(statusCode, headers, statusCode.getReasonPhrase());
     }
 
 }

--- a/src/main/java/webserver/resolver/ResolveResponse.java
+++ b/src/main/java/webserver/resolver/ResolveResponse.java
@@ -1,0 +1,63 @@
+package webserver.resolver;
+
+import com.sun.net.httpserver.Headers;
+import webserver.http.common.ContentType;
+import webserver.http.common.HttpHeaders;
+import webserver.http.response.HttpStatusCode;
+
+import static webserver.http.response.HttpStatusCode.*;
+
+public class ResolveResponse<T> {
+    private final HttpStatusCode statusCode;
+    private final HttpHeaders headers;
+    private final T body;
+
+    private ResolveResponse(HttpStatusCode statusCode, HttpHeaders headers, T body) {
+        this.statusCode = statusCode;
+        this.headers = headers;
+        this.body = body;
+    }
+
+    public HttpStatusCode getStatusCode() {
+        return statusCode;
+    }
+
+    public HttpHeaders getHeaders() {
+        return headers;
+    }
+
+    public T getBody() {
+        return body;
+    }
+
+    public static <T> ResolveResponse<T> ok(T body) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", ContentType.HTML.getMimeType());
+        return new ResolveResponse<>(OK, headers, body);
+    }
+
+    public static <T> ResolveResponse<T> ok(HttpStatusCode statusCode, T body) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "text/html;charset=utf-8");
+        return new ResolveResponse<>(statusCode, headers, body);
+    }
+
+    public static <T> ResolveResponse<T> ok(T body, ContentType contentType) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", contentType.getMimeType());
+        return new ResolveResponse<>(OK, headers, body);
+    }
+
+    public static <T> ResolveResponse<T> badRequest(T body) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", ContentType.HTML.getMimeType());
+        return new ResolveResponse<>(BAD_REQUEST, headers, body);
+    }
+
+    public static <T> ResolveResponse<T> notFound(T body) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", ContentType.HTML.getMimeType());
+        return new ResolveResponse<>(NOT_FOUND, headers, body);
+    }
+
+}

--- a/src/main/java/webserver/resolver/ResolveResponse.java
+++ b/src/main/java/webserver/resolver/ResolveResponse.java
@@ -5,6 +5,7 @@ import webserver.http.common.ContentType;
 import webserver.http.common.HttpHeaders;
 import webserver.http.response.HttpStatusCode;
 
+import static webserver.http.common.ContentType.HTML;
 import static webserver.http.response.HttpStatusCode.*;
 
 public class ResolveResponse<T> {
@@ -32,31 +33,32 @@ public class ResolveResponse<T> {
 
     public static <T> ResolveResponse<T> ok(T body) {
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", ContentType.HTML.getMimeType());
+        headers.add("Content-Type", HTML.getMimeType());
+        headers.addContentType(HTML);
         return new ResolveResponse<>(OK, headers, body);
     }
 
     public static <T> ResolveResponse<T> ok(HttpStatusCode statusCode, T body) {
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", "text/html;charset=utf-8");
+        headers.addContentType(HTML);
         return new ResolveResponse<>(statusCode, headers, body);
     }
 
     public static <T> ResolveResponse<T> ok(T body, ContentType contentType) {
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", contentType.getMimeType());
+        headers.addContentType(contentType);
         return new ResolveResponse<>(OK, headers, body);
     }
 
     public static <T> ResolveResponse<T> badRequest(T body) {
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", ContentType.HTML.getMimeType());
+        headers.addContentType(HTML);
         return new ResolveResponse<>(BAD_REQUEST, headers, body);
     }
 
     public static <T> ResolveResponse<T> notFound(T body) {
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", ContentType.HTML.getMimeType());
+        headers.addContentType(HTML);
         return new ResolveResponse<>(NOT_FOUND, headers, body);
     }
 

--- a/src/main/java/webserver/resolver/Resolver.java
+++ b/src/main/java/webserver/resolver/Resolver.java
@@ -1,0 +1,9 @@
+package webserver.resolver;
+
+import java.io.IOException;
+
+public interface Resolver {
+
+    void resolve() throws IOException;
+
+}

--- a/src/main/java/webserver/resolver/Resolver.java
+++ b/src/main/java/webserver/resolver/Resolver.java
@@ -1,11 +1,9 @@
 package webserver.resolver;
 
-import webserver.http.response.HttpResponse;
-
 import java.io.IOException;
 
 public interface Resolver {
 
-     HttpResponse resolve() throws IOException;
+    ResolveResponse<?> resolve() throws IOException;
 
 }

--- a/src/main/java/webserver/resolver/Resolver.java
+++ b/src/main/java/webserver/resolver/Resolver.java
@@ -1,9 +1,11 @@
 package webserver.resolver;
 
+import webserver.http.response.HttpResponse;
+
 import java.io.IOException;
 
 public interface Resolver {
 
-    void resolve() throws IOException;
+     HttpResponse resolve() throws IOException;
 
 }

--- a/src/main/java/webserver/resolver/ResourceResolver.java
+++ b/src/main/java/webserver/resolver/ResourceResolver.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.http.HttpRequest;
 import webserver.http.HttpResponse;
+import webserver.http.common.ContentType;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -26,39 +27,17 @@ public class ResourceResolver {
         InputStream fileIn = getClass().getClassLoader().getResourceAsStream(BASE_PATH + uri);
         if (fileIn != null) {
             byte[] body = fileIn.readAllBytes();
-            String contentType = getContentType(uri);
+            if (!ContentType.matches(uri)) {
+                logger.error("Unsupported content type for URI: {}", uri);
+                response.send415();
+                return;
+            }
+            String contentType = ContentType.getContentType(uri);
             response.sendResponse(200, "OK", contentType, body);
 
         } else {
             logger.error("File not found: static{}", uri);
             response.send404();
-        }
-    }
-
-    private String getContentType(String uri) {
-        String lowerUri = uri.toLowerCase();
-        if (lowerUri.endsWith(".html") || lowerUri.endsWith(".htm")) {
-            return "text/html;charset=utf-8";
-        } else if (lowerUri.endsWith(".css")) {
-            return "text/css;charset=utf-8";
-        } else if (lowerUri.endsWith(".js")) {
-            return "application/javascript;charset=utf-8";
-        } else if (lowerUri.endsWith(".png")) {
-            return "image/png";
-        } else if (lowerUri.endsWith(".svg")) {
-            return "image/svg+xml";
-        } else if (lowerUri.endsWith(".ico")) {
-            return "image/x-icon";
-        } else if (lowerUri.endsWith(".jpg") || lowerUri.endsWith(".jpeg")) {
-            return "image/jpeg";
-        } else if (lowerUri.endsWith(".gif")) {
-            return "image/gif";
-        } else if (lowerUri.endsWith(".json")) {
-            return "application/json;charset=utf-8";
-        } else if (lowerUri.endsWith(".xml")) {
-            return "application/xml;charset=utf-8";
-        } else {
-            return "application/octet-stream";
         }
     }
 

--- a/src/main/java/webserver/resolver/ResourceResolver.java
+++ b/src/main/java/webserver/resolver/ResourceResolver.java
@@ -9,7 +9,7 @@ import webserver.http.common.ContentType;
 import java.io.IOException;
 import java.io.InputStream;
 
-public class ResourceResolver {
+public class ResourceResolver implements Resolver {
 
     private static final Logger logger = LoggerFactory.getLogger(ResourceResolver.class);
     private static final String BASE_PATH = "static";
@@ -21,6 +21,7 @@ public class ResourceResolver {
         this.response = response;
     }
 
+    @Override
     public void resolve() throws IOException {
         String path = request.getRequestLine().getPath();
 

--- a/src/main/java/webserver/resolver/ResourceResolver.java
+++ b/src/main/java/webserver/resolver/ResourceResolver.java
@@ -39,7 +39,7 @@ public class ResourceResolver implements Resolver {
         }
 
         ContentType contentType = ContentType.getContentType(path);
-        return ResolveResponse.ok(body, contentType);
+        return ResolveResponse.ok(contentType, body);
     }
 
 }

--- a/src/main/java/webserver/resolver/ResourceResolver.java
+++ b/src/main/java/webserver/resolver/ResourceResolver.java
@@ -33,7 +33,7 @@ public class ResourceResolver implements Resolver {
 
         byte[] body = readResourceBytes(resourceUrl);
 
-        if (!ContentType.matches(path)) {
+        if (!ContentType.matches(resourceUrl.toString())) {
             logger.error("Unsupported content type for URI: {}", path);
             throw new HttpException(UNSUPPORTED_MEDIA_TYPE);
         }

--- a/src/main/java/webserver/resolver/ResourceResolver.java
+++ b/src/main/java/webserver/resolver/ResourceResolver.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import webserver.http.request.HttpRequest;
 import webserver.http.response.HttpResponse;
 import webserver.http.common.ContentType;
+import webserver.http.response.HttpStatusCode;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,19 +29,19 @@ public class ResourceResolver implements Resolver {
         InputStream fileIn = getClass().getClassLoader().getResourceAsStream(BASE_PATH + path);
         if (fileIn == null) {
             logger.error("File not found: static{}", path);
-            response.send404();
+            response.sendResponse(HttpStatusCode.NOT_FOUND, "application/json", "{\"error\": \"File not found\"}".getBytes());
             return;
         }
 
         byte[] body = fileIn.readAllBytes();
         if (!ContentType.matches(path)) {
             logger.error("Unsupported content type for URI: {}", path);
-            response.send415();
+            response.sendResponse(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE, "application/json", "{\"error\": \"Unsupported content type\"}".getBytes());
             return;
         }
 
         String contentType = ContentType.getContentType(path);
-        response.sendResponse(200, "OK", contentType, body);
+        response.sendResponse(HttpStatusCode.OK, contentType, body);
     }
 
 }

--- a/src/main/java/webserver/resolver/ResourceResolver.java
+++ b/src/main/java/webserver/resolver/ResourceResolver.java
@@ -15,15 +15,13 @@ public class ResourceResolver implements Resolver {
     private static final Logger logger = LoggerFactory.getLogger(ResourceResolver.class);
     private static final String BASE_PATH = "static";
     private final HttpRequest request;
-    private final HttpResponse response;
 
-    public ResourceResolver(HttpRequest request, HttpResponse response) {
+    public ResourceResolver(HttpRequest request) {
         this.request = request;
-        this.response = response;
     }
 
     @Override
-    public void resolve() throws IOException {
+    public HttpResponse resolve() throws IOException {
         String path = request.getRequestLine().getPath();
 
         InputStream fileIn = getClass().getClassLoader().getResourceAsStream(BASE_PATH + path);

--- a/src/main/java/webserver/resolver/ResourceResolver.java
+++ b/src/main/java/webserver/resolver/ResourceResolver.java
@@ -22,23 +22,23 @@ public class ResourceResolver {
     }
 
     public void resolve() throws IOException {
-        String uri = request.getUri();
+        String path = request.getRequestLine().getPath();
 
-        InputStream fileIn = getClass().getClassLoader().getResourceAsStream(BASE_PATH + uri);
+        InputStream fileIn = getClass().getClassLoader().getResourceAsStream(BASE_PATH + path);
         if (fileIn == null) {
-            logger.error("File not found: static{}", uri);
+            logger.error("File not found: static{}", path);
             response.send404();
             return;
         }
 
         byte[] body = fileIn.readAllBytes();
-        if (!ContentType.matches(uri)) {
-            logger.error("Unsupported content type for URI: {}", uri);
+        if (!ContentType.matches(path)) {
+            logger.error("Unsupported content type for URI: {}", path);
             response.send415();
             return;
         }
 
-        String contentType = ContentType.getContentType(uri);
+        String contentType = ContentType.getContentType(path);
         response.sendResponse(200, "OK", contentType, body);
     }
 

--- a/src/main/java/webserver/resolver/ResourceResolver.java
+++ b/src/main/java/webserver/resolver/ResourceResolver.java
@@ -29,18 +29,18 @@ public class ResourceResolver implements Resolver {
         InputStream fileIn = getClass().getClassLoader().getResourceAsStream(BASE_PATH + path);
         if (fileIn == null) {
             logger.error("File not found: static{}", path);
-            response.sendResponse(HttpStatusCode.NOT_FOUND, "application/json", "{\"error\": \"File not found\"}".getBytes());
+            response.sendResponse(HttpStatusCode.NOT_FOUND, ContentType.JSON, "{\"error\": \"File not found\"}".getBytes());
             return;
         }
 
         byte[] body = fileIn.readAllBytes();
         if (!ContentType.matches(path)) {
             logger.error("Unsupported content type for URI: {}", path);
-            response.sendResponse(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE, "application/json", "{\"error\": \"Unsupported content type\"}".getBytes());
+            response.sendResponse(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE, ContentType.JSON, "{\"error\": \"Unsupported content type\"}".getBytes());
             return;
         }
 
-        String contentType = ContentType.getContentType(path);
+        ContentType contentType = ContentType.getContentType(path);
         response.sendResponse(HttpStatusCode.OK, contentType, body);
     }
 

--- a/src/main/java/webserver/resolver/ResourceResolver.java
+++ b/src/main/java/webserver/resolver/ResourceResolver.java
@@ -25,20 +25,21 @@ public class ResourceResolver {
         String uri = request.getUri();
 
         InputStream fileIn = getClass().getClassLoader().getResourceAsStream(BASE_PATH + uri);
-        if (fileIn != null) {
-            byte[] body = fileIn.readAllBytes();
-            if (!ContentType.matches(uri)) {
-                logger.error("Unsupported content type for URI: {}", uri);
-                response.send415();
-                return;
-            }
-            String contentType = ContentType.getContentType(uri);
-            response.sendResponse(200, "OK", contentType, body);
-
-        } else {
+        if (fileIn == null) {
             logger.error("File not found: static{}", uri);
             response.send404();
+            return;
         }
+
+        byte[] body = fileIn.readAllBytes();
+        if (!ContentType.matches(uri)) {
+            logger.error("Unsupported content type for URI: {}", uri);
+            response.send415();
+            return;
+        }
+
+        String contentType = ContentType.getContentType(uri);
+        response.sendResponse(200, "OK", contentType, body);
     }
 
 }

--- a/src/main/java/webserver/resolver/ResourceResolver.java
+++ b/src/main/java/webserver/resolver/ResourceResolver.java
@@ -6,16 +6,20 @@ import webserver.http.common.ContentType;
 import webserver.http.exception.HttpException;
 import webserver.http.request.HttpRequest;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
 
-import static webserver.http.response.HttpStatusCode.NOT_FOUND;
-import static webserver.http.response.HttpStatusCode.UNSUPPORTED_MEDIA_TYPE;
+import static webserver.http.response.HttpStatusCode.*;
 
 public class ResourceResolver implements Resolver {
 
     private static final Logger logger = LoggerFactory.getLogger(ResourceResolver.class);
     private static final String BASE_PATH = "static";
+    private static final String INDEX_FILE = "index.html";
+    private static final String FILE_PROTOCOL = "file";
     private final HttpRequest request;
 
     public ResourceResolver(HttpRequest request) {
@@ -23,23 +27,57 @@ public class ResourceResolver implements Resolver {
     }
 
     @Override
-    public ResolveResponse<byte[]> resolve() throws IOException {
+    public ResolveResponse<byte[]> resolve() {
         String path = request.getRequestLine().getPath();
+        URL resourceUrl = resolveResourceUrl(BASE_PATH + path);
 
-        InputStream fileIn = getClass().getClassLoader().getResourceAsStream(BASE_PATH + path);
-        if (fileIn == null) {
-            logger.error("File not found: static{}", path);
-            throw new HttpException(NOT_FOUND);
-        }
+        byte[] body = readResourceBytes(resourceUrl);
 
-        byte[] body = fileIn.readAllBytes();
         if (!ContentType.matches(path)) {
             logger.error("Unsupported content type for URI: {}", path);
             throw new HttpException(UNSUPPORTED_MEDIA_TYPE);
         }
 
-        ContentType contentType = ContentType.getContentType(path);
+        ContentType contentType = ContentType.getContentType(resourceUrl.toString());
         return ResolveResponse.ok(contentType, body);
+    }
+
+    private URL resolveResourceUrl(String fullPath) {
+        URL resourceUrl = getClass().getClassLoader().getResource(fullPath);
+        if (resourceUrl == null) {
+            logger.error("File not found: {}", fullPath);
+            throw new HttpException(NOT_FOUND);
+        }
+
+        if (resourceUrl.getProtocol().equals(FILE_PROTOCOL)) {
+            try {
+                File file = new File(resourceUrl.toURI());
+                if (file.isDirectory()) {
+                    if (!fullPath.endsWith("/")) {
+                        fullPath += "/";
+                    }
+                    fullPath += INDEX_FILE;
+                    resourceUrl = getClass().getClassLoader().getResource(fullPath);
+                    if (resourceUrl == null) {
+                        logger.error("Index file not found in directory: {}", fullPath);
+                        throw new HttpException(NOT_FOUND);
+                    }
+                }
+            } catch (URISyntaxException e) {
+                logger.error("Invalid URI syntax for resource: {}", e.getMessage());
+                throw new HttpException(NOT_FOUND);
+            }
+        }
+
+        return resourceUrl;
+    }
+
+    private byte[] readResourceBytes(URL resourceUrl) {
+        try (InputStream in = resourceUrl.openStream()) {
+            return in.readAllBytes();
+        } catch (IOException e) {
+            throw new HttpException(INTERNAL_SERVER_ERROR);
+        }
     }
 
 }

--- a/src/main/java/webserver/resolver/ResourceResolver.java
+++ b/src/main/java/webserver/resolver/ResourceResolver.java
@@ -2,8 +2,8 @@ package webserver.resolver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import webserver.http.HttpRequest;
-import webserver.http.HttpResponse;
+import webserver.http.request.HttpRequest;
+import webserver.http.response.HttpResponse;
 import webserver.http.common.ContentType;
 
 import java.io.IOException;

--- a/src/main/java/webserver/resolver/ResourceResolver.java
+++ b/src/main/java/webserver/resolver/ResourceResolver.java
@@ -2,13 +2,15 @@ package webserver.resolver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import webserver.http.request.HttpRequest;
-import webserver.http.response.HttpResponse;
 import webserver.http.common.ContentType;
-import webserver.http.response.HttpStatusCode;
+import webserver.http.exception.HttpException;
+import webserver.http.request.HttpRequest;
 
 import java.io.IOException;
 import java.io.InputStream;
+
+import static webserver.http.response.HttpStatusCode.NOT_FOUND;
+import static webserver.http.response.HttpStatusCode.UNSUPPORTED_MEDIA_TYPE;
 
 public class ResourceResolver implements Resolver {
 
@@ -21,25 +23,23 @@ public class ResourceResolver implements Resolver {
     }
 
     @Override
-    public HttpResponse resolve() throws IOException {
+    public ResolveResponse<byte[]> resolve() throws IOException {
         String path = request.getRequestLine().getPath();
 
         InputStream fileIn = getClass().getClassLoader().getResourceAsStream(BASE_PATH + path);
         if (fileIn == null) {
             logger.error("File not found: static{}", path);
-            response.sendResponse(HttpStatusCode.NOT_FOUND, ContentType.HTML, "<h1>File Not Found</h1>".getBytes());
-            return;
+            throw new HttpException(NOT_FOUND);
         }
 
         byte[] body = fileIn.readAllBytes();
         if (!ContentType.matches(path)) {
             logger.error("Unsupported content type for URI: {}", path);
-            response.sendResponse(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE, ContentType.HTML, "<h1>Unsupported Media Type</h1>".getBytes());
-            return;
+            throw new HttpException(UNSUPPORTED_MEDIA_TYPE);
         }
 
         ContentType contentType = ContentType.getContentType(path);
-        response.sendResponse(HttpStatusCode.OK, contentType, body);
+        return ResolveResponse.ok(body, contentType);
     }
 
 }

--- a/src/main/java/webserver/resolver/ResourceResolver.java
+++ b/src/main/java/webserver/resolver/ResourceResolver.java
@@ -29,14 +29,14 @@ public class ResourceResolver implements Resolver {
         InputStream fileIn = getClass().getClassLoader().getResourceAsStream(BASE_PATH + path);
         if (fileIn == null) {
             logger.error("File not found: static{}", path);
-            response.sendResponse(HttpStatusCode.NOT_FOUND, ContentType.JSON, "{\"error\": \"File not found\"}".getBytes());
+            response.sendResponse(HttpStatusCode.NOT_FOUND, ContentType.HTML, "<h1>File Not Found</h1>".getBytes());
             return;
         }
 
         byte[] body = fileIn.readAllBytes();
         if (!ContentType.matches(path)) {
             logger.error("Unsupported content type for URI: {}", path);
-            response.sendResponse(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE, ContentType.JSON, "{\"error\": \"Unsupported content type\"}".getBytes());
+            response.sendResponse(HttpStatusCode.UNSUPPORTED_MEDIA_TYPE, ContentType.HTML, "<h1>Unsupported Media Type</h1>".getBytes());
             return;
         }
 

--- a/src/main/java/webserver/util/Convertor.java
+++ b/src/main/java/webserver/util/Convertor.java
@@ -21,4 +21,19 @@ public class Convertor {
         }
     }
 
+    public static byte[] convertToByteArray(Object body) {
+        try {
+            if (body instanceof String) {
+                return ((String) body).getBytes();
+            } else if (body instanceof byte[]) {
+                return (byte[]) body;
+            } else {
+                String json = Serializer.toJson(body);
+                return json.getBytes();
+            }
+        } catch (IllegalAccessException e) {
+            throw new IllegalArgumentException("Cannot convert " + body + " to byte[]", e);
+        }
+    }
+
 }

--- a/src/main/java/webserver/util/Convertor.java
+++ b/src/main/java/webserver/util/Convertor.java
@@ -1,0 +1,24 @@
+package webserver.util;
+
+public class Convertor {
+
+    private Convertor() {
+    }
+
+    public static long convertToLong(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid number format: " + value, e);
+        }
+    }
+
+    public static int convertToIntByHex(String value) {
+        try {
+            return Integer.parseInt(value.trim(), 16);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid number format: " + value, e);
+        }
+    }
+
+}

--- a/src/main/java/webserver/util/Convertor.java
+++ b/src/main/java/webserver/util/Convertor.java
@@ -25,12 +25,12 @@ public class Convertor {
         try {
             if (body instanceof String) {
                 return ((String) body).getBytes();
-            } else if (body instanceof byte[]) {
-                return (byte[]) body;
-            } else {
-                String json = Serializer.toJson(body);
-                return json.getBytes();
             }
+            if (body instanceof byte[]) {
+                return (byte[]) body;
+            }
+            String json = Serializer.toJson(body);
+            return json.getBytes();
         } catch (IllegalAccessException e) {
             throw new IllegalArgumentException("Cannot convert " + body + " to byte[]", e);
         }

--- a/src/main/java/webserver/util/Serializer.java
+++ b/src/main/java/webserver/util/Serializer.java
@@ -1,0 +1,69 @@
+package webserver.util;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+
+public class Serializer {
+
+    // RFC 8259 (JSON 데이터 interchange format)에서도 모든 키와 문자열 값은 반드시 큰따옴표로 감싸야 한다고 명시하고 있습니다.
+    public static String toJson(Object obj) throws IllegalAccessException {
+        if (obj == null) {
+            return "null";
+        }
+
+        Class<?> clazz = obj.getClass();
+
+        // String 처리: 따옴표와 내부 따옴표 이스케이프 처리
+        if (clazz == String.class) {
+            return "\"" + escape((String) obj) + "\"";
+        }
+
+        if (clazz == Integer.class || clazz == Long.class || clazz == Double.class ||
+                clazz == Float.class || clazz == Boolean.class || Number.class.isAssignableFrom(clazz)) {
+            return obj.toString();
+        }
+
+        // 배열 처리
+        if (clazz.isArray()) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("[");
+            int length = Array.getLength(obj);
+            for (int i = 0; i < length; i++) {
+                Object element = Array.get(obj, i);
+                sb.append(toJson(element));
+                if (i < length - 1) {
+                    sb.append(",");
+                }
+            }
+            sb.append("]");
+            return sb.toString();
+        }
+
+        // 객체(빈 객체 또는 POJO) 처리: 모든 필드를 JSON 객체로 변환
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        Field[] fields = clazz.getDeclaredFields();
+        boolean first = true;
+        for (Field field : fields) {
+            field.setAccessible(true);
+            Object value = field.get(obj);
+            if (!first) {
+                sb.append(",");
+            }
+            sb.append("\"").append(field.getName()).append("\":");
+            sb.append(toJson(value));
+            first = false;
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private static String escape(String s) {
+        return s.replace("\\", "\\\\")
+                .replace("\"", "\\\"")
+                .replace("\n", "\\n")
+                .replace("\r", "\\r")
+                .replace("\t", "\\t");
+    }
+
+}

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -1,64 +1,63 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="../reset.css" rel="stylesheet" />
-    <link href="../global.css" rel="stylesheet" />
-  </head>
-  <body>
-    <div class="container">
-      <header class="header">
-        <a href="/"><img src="../img/signiture.svg" /></a>
-        <ul class="header__menu">
-          <li class="header__menu__item">
-            <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
-          </li>
-          <li class="header__menu__item">
-            <a class="btn btn_ghost btn_size_s" href="/registration">
-              회원 가입
-            </a>
-          </li>
-        </ul>
-      </header>
-      <div class="page">
-        <h2 class="page-title">회원가입</h2>
-        <form class="form">
-          <div class="textfield textfield_size_s">
-            <p class="title_textfield">아이디</p>
-            <input
-              class="input_textfield"
-              placeholder="아이디를 입력해주세요"
-              autocomplete="username"
-            />
-          </div>
-          <div class="textfield textfield_size_s">
-            <p class="title_textfield">닉네임</p>
-            <input
-              class="input_textfield"
-              placeholder="닉네임을 입력해주세요"
-              autocomplete="username"
-            />
-          </div>
-          <div class="textfield textfield_size_s">
-            <p class="title_textfield">비밀번호</p>
-            <input
-              class="input_textfield"
-              type="password"
-              placeholder="비밀번호를 입력해주세요"
-              autocomplete="current-password"
-            />
-          </div>
-          <button
-            id="registration-btn"
-            class="btn btn_contained btn_size_m"
-            style="margin-top: 24px"
-            type="button"
-          >
-            회원가입
-          </button>
-        </form>
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link href="../reset.css" rel="stylesheet" />
+  <link href="../global.css" rel="stylesheet" />
+</head>
+<body>
+<div class="container">
+  <header class="header">
+    <a href="/"><img src="../img/signiture.svg" alt="사이트 로고" /></a>
+    <ul class="header__menu">
+      <li class="header__menu__item">
+        <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
+      </li>
+      <li class="header__menu__item">
+        <a class="btn btn_ghost btn_size_s" href="/registration">
+          회원 가입
+        </a>
+      </li>
+    </ul>
+  </header>
+  <div class="page">
+    <h2 class="page-title">회원가입</h2>
+    <form class="form" method="get" action="/create">
+      <div class="textfield textfield_size_s">
+        <p class="title_textfield">아이디</p>
+        <input
+                name="username"
+                class="input_textfield"
+                placeholder="아이디를 입력해주세요"
+                autocomplete="username" />
       </div>
-    </div>
-  </body>
+      <div class="textfield textfield_size_s">
+        <p class="title_textfield">닉네임</p>
+        <input
+                name="nickname"
+                class="input_textfield"
+                placeholder="닉네임을 입력해주세요"
+                autocomplete="nickname" />
+      </div>
+      <div class="textfield textfield_size_s">
+        <p class="title_textfield">비밀번호</p>
+        <input
+                name="password"
+                class="input_textfield"
+                type="password"
+                placeholder="비밀번호를 입력해주세요"
+                autocomplete="current-password" />
+      </div>
+      <button
+              id="registration-btn"
+              class="btn btn_contained btn_size_m"
+              style="margin-top: 24px"
+              type="submit">
+        회원가입
+      </button>
+    </form>
+  </div>
+</div>
+</body>
 </html>

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -24,22 +24,34 @@
   <div class="page">
     <h2 class="page-title">회원가입</h2>
     <form class="form" method="get" action="/create">
+      <!-- 아이디 필드: userId라는 이름으로 전송 -->
       <div class="textfield textfield_size_s">
         <p class="title_textfield">아이디</p>
         <input
-                name="username"
+                name="userId"
                 class="input_textfield"
                 placeholder="아이디를 입력해주세요"
                 autocomplete="username" />
       </div>
+      <!-- 닉네임 필드: name이라는 이름으로 전송 -->
       <div class="textfield textfield_size_s">
         <p class="title_textfield">닉네임</p>
         <input
-                name="nickname"
+                name="name"
                 class="input_textfield"
                 placeholder="닉네임을 입력해주세요"
                 autocomplete="nickname" />
       </div>
+      <!-- 이메일 필드: email이라는 이름으로 전송 -->
+      <div class="textfield textfield_size_s">
+        <p class="title_textfield">이메일</p>
+        <input
+                name="email"
+                class="input_textfield"
+                placeholder="이메일을 입력해주세요"
+                autocomplete="email" />
+      </div>
+      <!-- 비밀번호 필드 -->
       <div class="textfield textfield_size_s">
         <p class="title_textfield">비밀번호</p>
         <input

--- a/src/test/java/webserver/http/HttpRequestTest.java
+++ b/src/test/java/webserver/http/HttpRequestTest.java
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import webserver.http.exception.RequestParseException;
+import webserver.http.request.HttpRequest;
 
 import java.io.BufferedReader;
 import java.io.StringReader;

--- a/src/test/java/webserver/http/HttpResponseTest.java
+++ b/src/test/java/webserver/http/HttpResponseTest.java
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import webserver.http.response.HttpResponse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;

--- a/src/test/java/webserver/http/request/ABNFRequestParserTest.java
+++ b/src/test/java/webserver/http/request/ABNFRequestParserTest.java
@@ -1,0 +1,169 @@
+package webserver.http.request;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import webserver.http.exception.RequestParseException;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ABNFRequestParserTest {
+
+    @Test
+    @DisplayName("Content-Length가 포함된 정상 요청: 200 OK와 올바른 본문 반환")
+    void 정상_요청_ContentLength_테스트() throws IOException {
+        // given
+        String requestString =
+                "GET /hello HTTP/1.1\r\n" +
+                        "Host: example.com\r\n" +
+                        "Content-Length: 5\r\n" +
+                        "\r\n" +
+                        "Hello";
+        BufferedReader reader = new BufferedReader(new StringReader(requestString));
+        ABNFRequestParser parser = new ABNFRequestParser(reader);
+
+        // when
+        HttpRequest httpRequest = parser.parseRequest();
+
+        // then
+        assertThat(httpRequest.getRequestLine().toString()).isEqualTo("GET /hello HTTP/1.1");
+        assertThat(httpRequest.getBody()).isEqualTo("Hello");
+        assertThat(httpRequest.getHeaders().toString()).contains("example.com");
+    }
+
+    @Test
+    @DisplayName("Chunked 인코딩 정상 요청: 올바른 본문 반환")
+    void 정상_요청_Chunked_테스트() throws IOException {
+        // given: Transfer-Encoding: chunked가 포함된 요청 문자열. 하나의 청크("Hello")와 마지막 청크("0")가 포함됨.
+        String requestString =
+                "GET /chunk HTTP/1.1\r\n" +
+                        "Host: example.com\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "\r\n" +
+                        "5\r\n" +
+                        "Hello\r\n" +
+                        "0\r\n" +
+                        "\r\n";
+        BufferedReader reader = new BufferedReader(new StringReader(requestString));
+        ABNFRequestParser parser = new ABNFRequestParser(reader);
+
+        // when
+        HttpRequest httpRequest = parser.parseRequest();
+
+        // then
+        assertThat(httpRequest.getBody()).isEqualTo("Hello");
+    }
+
+    @Test
+    @DisplayName("잘못된 요청 라인: RequestParseException 발생")
+    void 잘못된_요청라인_테스트() {
+        // given: HTTP 버전이 누락되어 잘못된 요청 라인("GET /hello")을 가진 요청 문자열
+        String requestString =
+                "GET /hello\r\n" +
+                        "\r\n";
+        BufferedReader reader = new BufferedReader(new StringReader(requestString));
+        ABNFRequestParser parser = new ABNFRequestParser(reader);
+
+        // when & then
+        assertThatThrownBy(parser::parseRequest)
+                .isInstanceOf(RequestParseException.class)
+                .hasMessageContaining("Invalid Request-Line");
+    }
+
+    @Test
+    @DisplayName("잘못된 헤더 형식: RequestParseException 발생")
+    void 잘못된_헤더형식_테스트() {
+        // given
+        String requestString =
+                "GET /hello HTTP/1.1\r\n" +
+                        "InvalidHeaderLine\r\n" +
+                        "\r\n" +
+                        "Hello";
+        BufferedReader reader = new BufferedReader(new StringReader(requestString));
+        ABNFRequestParser parser = new ABNFRequestParser(reader);
+
+        // when & then
+        assertThatThrownBy(parser::parseRequest)
+                .isInstanceOf(RequestParseException.class)
+                .hasMessageContaining("Invalid header field");
+    }
+
+    @Test
+    @DisplayName("CR 뒤 LF 누락: RequestParseException 발생")
+    void CR뒤_LF_누락_테스트() {
+        // given
+        String requestString = "GET /hello HTTP/1.1\r";  // LF 누락
+        BufferedReader reader = new BufferedReader(new StringReader(requestString));
+        ABNFRequestParser parser = new ABNFRequestParser(reader);
+
+        // when & then
+        assertThatThrownBy(parser::parseRequest)
+                .isInstanceOf(RequestParseException.class)
+                .hasMessageContaining("Invalid request line");
+    }
+
+    @Test
+    @DisplayName("본문 길이가 부족한 경우: IOException 발생")
+    void 본문_부족_ContentLength_테스트() {
+        // given: Content-Length가 10으로 지정되어 있지만 실제 본문은 "Hello"(5글자)만 있는 요청 문자열
+        String requestString =
+                "GET /hello HTTP/1.1\r\n" +
+                        "Content-Length: 10\r\n" +
+                        "\r\n" +
+                        "Hello";
+        BufferedReader reader = new BufferedReader(new StringReader(requestString));
+        ABNFRequestParser parser = new ABNFRequestParser(reader);
+
+        // when & then
+        assertThatThrownBy(parser::parseRequest)
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Expected 10 bytes");
+    }
+
+    @Test
+    @DisplayName("청크 데이터가 부족한 경우: RequestParseException 발생")
+    void 청크데이터_부족_테스트() {
+        // given: 청크 길이가 5로 지정되었으나 실제 청크 데이터는 "Hel"(3글자)만 제공하는 요청 문자열
+        String requestString =
+                "GET /chunk HTTP/1.1\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "\r\n" +
+                        "5\r\n" +
+                        "Hel\r\n" +
+                        "0\r\n" +
+                        "\r\n";
+        BufferedReader reader = new BufferedReader(new StringReader(requestString));
+        ABNFRequestParser parser = new ABNFRequestParser(reader);
+
+        // when & then
+        assertThatThrownBy(parser::parseRequest)
+                .isInstanceOf(RequestParseException.class)
+                .hasMessageContaining("Expected CRLF after chunk data");
+    }
+
+    @Test
+    @DisplayName("청크 데이터 후 CRLF 누락: RequestParseException 발생")
+    void 청크데이터_CRLF_누락_테스트() {
+        // given: 청크 데이터 후 빈 CRLF(줄바꿈)가 누락된 잘못된 요청 문자열
+        String requestString =
+                "GET /chunk HTTP/1.1\r\n" +
+                        "Transfer-Encoding: chunked\r\n" +
+                        "\r\n" +
+                        "5\r\n" +
+                        "HelloX\r\n" +  // "Hello" 후에 CRLF로 인식되어야 할 부분에 "X" 문자가 남음
+                        "0\r\n" +
+                        "\r\n";
+        BufferedReader reader = new BufferedReader(new StringReader(requestString));
+        ABNFRequestParser parser = new ABNFRequestParser(reader);
+
+        // when & then
+        assertThatThrownBy(parser::parseRequest)
+                .isInstanceOf(RequestParseException.class)
+                .hasMessageContaining("Expected CRLF after chunk data");
+    }
+
+}

--- a/src/test/java/webserver/http/request/HttpRequestTest.java
+++ b/src/test/java/webserver/http/request/HttpRequestTest.java
@@ -1,10 +1,9 @@
-package webserver.http;
+package webserver.http.request;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import webserver.http.exception.RequestParseException;
-import webserver.http.request.HttpRequest;
 
 import java.io.BufferedReader;
 import java.io.StringReader;

--- a/src/test/java/webserver/http/request/HttpRequestTest.java
+++ b/src/test/java/webserver/http/request/HttpRequestTest.java
@@ -1,12 +1,12 @@
 package webserver.http.request;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import webserver.http.exception.RequestParseException;
 
 import java.io.BufferedReader;
 import java.io.StringReader;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class HttpRequestTest {
 
@@ -27,25 +27,12 @@ class HttpRequestTest {
         HttpRequest request = new HttpRequest(reader);
 
         // Then
-        Assertions.assertThat(request.getMethod()).isEqualTo("GET");
-        Assertions.assertThat(request.getUri()).isEqualTo("/index.html");
-        Assertions.assertThat(request.getProtocol()).isEqualTo("HTTP/1.1");
-        Assertions.assertThat(request.getHeaders())
+        assertThat(request.getHeaders())
                 .containsEntry("Host", "localhost")
                 .containsEntry("User-Agent", "TestAgent");
-    }
-
-    @Test
-    @DisplayName("빈 요청 문자열 파싱 시: RequestParseException 예외가 발생해야 한다.")
-    public void 헤더_파싱_예외_테스트() {
-        // Given
-        String requestStr = "\r\n";
-        BufferedReader reader = new BufferedReader(new StringReader(requestStr));
-
-        // When & Then
-        Assertions.assertThatThrownBy(() -> new HttpRequest(reader))
-                .isInstanceOf(RequestParseException.class)
-                .hasMessageContaining("Empty request line");
+        assertThat(request.getRequestLine().getMethod().toString()).isEqualTo("GET");
+        assertThat(request.getRequestLine().getPath()).isEqualTo("/index.html");
+        assertThat(request.getRequestLine().getHttpVersion()).isEqualTo("HTTP/1.1");
     }
 
 }

--- a/src/test/java/webserver/http/request/HttpRequestTest.java
+++ b/src/test/java/webserver/http/request/HttpRequestTest.java
@@ -2,37 +2,29 @@ package webserver.http.request;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.io.BufferedReader;
-import java.io.StringReader;
+import webserver.http.common.HttpHeaders;
+import webserver.http.common.HttpMethod;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class HttpRequestTest {
 
     @Test
-    @DisplayName("정상 요청 문자열 파싱: 올바른 메서드, URI, 프로토콜 및 헤더를 추출해야 한다.")
-    public void 헤더_정상_파싱_테스트() throws Exception {
+    @DisplayName("HTTP 요청 객체가 올바르게 생성되어야 한다.")
+    void 객체_생성_테스트() {
         // Given
-        String requestStr =
-                """
-                        GET /index.html HTTP/1.1\r
-                        Host: localhost\r
-                        User-Agent: TestAgent\r
-                        \r
-                        """;
-        BufferedReader reader = new BufferedReader(new StringReader(requestStr));
+        String requestLine = "GET /index.html HTTP/1.1";
+        HttpHeaders headers = new HttpHeaders();
+        String body = "Hello, World!";
 
         // When
-        HttpRequest request = new HttpRequest(reader);
+        HttpRequest httpRequest = new HttpRequest(new RequestLine(requestLine), headers, body);
 
         // Then
-        assertThat(request.getHeaders())
-                .containsEntry("Host", "localhost")
-                .containsEntry("User-Agent", "TestAgent");
-        assertThat(request.getRequestLine().getMethod().toString()).isEqualTo("GET");
-        assertThat(request.getRequestLine().getPath()).isEqualTo("/index.html");
-        assertThat(request.getRequestLine().getHttpVersion()).isEqualTo("HTTP/1.1");
+        assertThat(httpRequest.getRequestLine().getMethod()).isEqualTo(HttpMethod.GET);
+        assertThat(httpRequest.getRequestLine().getPath()).isEqualTo("/index.html");
+        assertThat(httpRequest.getHeaders()).isEqualTo(headers);
+        assertThat(httpRequest.getBody()).isEqualTo(body);
     }
 
 }

--- a/src/test/java/webserver/http/request/RequestLineTest.java
+++ b/src/test/java/webserver/http/request/RequestLineTest.java
@@ -1,0 +1,100 @@
+package webserver.http.request;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import webserver.http.exception.RequestParseException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RequestLineTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "'GET /index.html HTTP/1.1', GET, /index.html, HTTP/1.1",
+            "'POST /submit HTTP/1.0', POST, /submit, HTTP/1.0",
+            "'PUT /update HTTP/2.0', PUT, /update, HTTP/2.0"
+    })
+    @DisplayName("쿼리파람 없는 올바른 메서드, URI, 프로토콜 및 헤더를 추출해야 한다.")
+    void 정상_요청라인_파싱_테스트(String requestLine, String expectedMethod, String expectedPath, String expectedHttpVersion) {
+        // When
+        RequestLine requestLineObj = new RequestLine(requestLine);
+
+        // Then
+        assertThat(requestLineObj.getMethod().toString()).isEqualTo(expectedMethod);
+        assertThat(requestLineObj.getPath()).isEqualTo(expectedPath);
+        assertThat(requestLineObj.getHttpVersion()).isEqualTo(expectedHttpVersion);
+        assertThat(requestLineObj.getQueryString()).isEmpty();
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "'GET /index.html?name=John&age=30 HTTP/1.1', GET, /index.html, HTTP/1.1, name=John&age=30",
+            "'POST /submit?param=value HTTP/1.0', POST, /submit, HTTP/1.0, param=value",
+            "'PUT /update?key=value&key2=value2 HTTP/2.0', PUT, /update, HTTP/2.0, key=value&key2=value2",
+            "'DELETE /delete?item= HTTP/1.1', DELETE, /delete, HTTP/1.1, item=",
+
+    })
+    @DisplayName("쿼리파람 있는 올바른 메서드, URI, 프로토콜 및 헤더를 추출해야 한다.")
+    void 정상_쿼리파람_요청라인_파싱_테스트(String requestLine, String expectedMethod, String expectedPath, String expectedHttpVersion, String expectedQueryString) {
+        // When
+        RequestLine requestLineObj = new RequestLine(requestLine);
+
+        // Then
+        assertThat(requestLineObj.getMethod().toString()).isEqualTo(expectedMethod);
+        assertThat(requestLineObj.getPath()).isEqualTo(expectedPath);
+        assertThat(requestLineObj.getHttpVersion()).isEqualTo(expectedHttpVersion);
+
+        String[] expectedQueryParams = expectedQueryString.split("&");
+        for (String param : expectedQueryParams) {
+            String[] keyValue = param.split("=");
+            assertThat(requestLineObj.getQueryString()).containsEntry(keyValue[0], keyValue.length > 1 ? keyValue[1] : "");
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "GET /index.html HTTP/1.1 Host: localhost",
+            "POST /submit HTTP/1.0 INVALID_HEADER",
+            "PUT /update HTTP/2.0 MORE HEADERS",
+            "DELETE /delete",
+            "GET"
+    })
+    @DisplayName("잘못된 RequestLine 형식일 경우 RequestParseException 예외가 발생해야 한다.")
+    void 잘못된_요청라인_예외_테스트(String requestLine) {
+        // When & Then
+        assertThatThrownBy(() -> new RequestLine(requestLine))
+                .isInstanceOf(RequestParseException.class)
+                .hasMessageContaining("Invalid request line: ");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "GET /index.html HTTP/3",
+            "POST /submit HTTP/0",
+            "PUT /update HTTP/2",
+            "DELETE /delete HTTP/1"
+    })
+    @DisplayName("잘못된 HTTP 버전일 경우 RequestParseException 예외가 발생해야 한다.")
+    void 잘못된_http_버전_예외_테스트(String requestLine) {
+        // When & Then
+        assertThatThrownBy(() -> new RequestLine(requestLine))
+                .isInstanceOf(RequestParseException.class)
+                .hasMessageContaining("Invalid HTTP version: ");
+    }
+
+    @Test
+    @DisplayName("잘못된 Method 일 경우 RequestParseException 예외가 발생해야 한다.")
+    void 잘못된_method__예외_테스트() {
+        // Given
+        String requestLine = "INVALID_METHOD /index.html HTTP/1.1";
+
+        // When & Then
+        assertThatThrownBy(() -> new RequestLine(requestLine))
+                .isInstanceOf(RequestParseException.class)
+                .hasMessageContaining("Invalid HTTP method: ");
+    }
+
+}

--- a/src/test/java/webserver/http/response/HttpResponseTest.java
+++ b/src/test/java/webserver/http/response/HttpResponseTest.java
@@ -29,7 +29,7 @@ class HttpResponseTest {
         String body = "Hello World";
 
         // When
-        response.sendResponse(200, "OK", "text/plain", body.getBytes(StandardCharsets.UTF_8));
+        response.sendResponse(HttpStatusCode.OK, "text/plain", body.getBytes());
 
         // Then
         String output = baos.toString(StandardCharsets.UTF_8);
@@ -43,7 +43,7 @@ class HttpResponseTest {
     @DisplayName("send400() 호출 시, 400 Bad Request 응답이 전송되어야 한다.")
     public void 응답_400_테스트() throws IOException {
         // When
-        response.send400();
+        response.sendResponse(HttpStatusCode.BAD_REQUEST, "text/plain", "Bad Request".getBytes());
 
         // Then
         String output = baos.toString(StandardCharsets.UTF_8);
@@ -54,7 +54,7 @@ class HttpResponseTest {
     @DisplayName("send404() 호출 시, 404 Not Found 응답이 전송되어야 한다.")
     public void 응답_404_테스트() throws IOException {
         // When
-        response.send404();
+        response.sendResponse(HttpStatusCode.NOT_FOUND, "text/plain", "Not Found".getBytes());
 
         // Then
         String output = baos.toString();

--- a/src/test/java/webserver/http/response/HttpResponseTest.java
+++ b/src/test/java/webserver/http/response/HttpResponseTest.java
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import webserver.http.common.ContentType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -29,12 +30,12 @@ class HttpResponseTest {
         String body = "Hello World";
 
         // When
-        response.sendResponse(HttpStatusCode.OK, "text/plain", body.getBytes());
+        response.sendResponse(HttpStatusCode.OK, ContentType.JSON, body.getBytes());
 
         // Then
         String output = baos.toString(StandardCharsets.UTF_8);
         Assertions.assertThat(output).contains("HTTP/1.1 200 OK");
-        Assertions.assertThat(output).contains("Content-Type: text/plain");
+        Assertions.assertThat(output).contains("Content-Type: application/json");
         Assertions.assertThat(output).contains("Content-Length: " + body.getBytes().length);
         Assertions.assertThat(output).endsWith("Hello World");
     }
@@ -43,7 +44,7 @@ class HttpResponseTest {
     @DisplayName("send400() 호출 시, 400 Bad Request 응답이 전송되어야 한다.")
     public void 응답_400_테스트() throws IOException {
         // When
-        response.sendResponse(HttpStatusCode.BAD_REQUEST, "text/plain", "Bad Request".getBytes());
+        response.sendResponse(HttpStatusCode.BAD_REQUEST, ContentType.JSON, "Bad Request".getBytes());
 
         // Then
         String output = baos.toString(StandardCharsets.UTF_8);
@@ -54,7 +55,7 @@ class HttpResponseTest {
     @DisplayName("send404() 호출 시, 404 Not Found 응답이 전송되어야 한다.")
     public void 응답_404_테스트() throws IOException {
         // When
-        response.sendResponse(HttpStatusCode.NOT_FOUND, "text/plain", "Not Found".getBytes());
+        response.sendResponse(HttpStatusCode.NOT_FOUND, ContentType.JSON, "Not Found".getBytes());
 
         // Then
         String output = baos.toString();

--- a/src/test/java/webserver/http/response/HttpResponseTest.java
+++ b/src/test/java/webserver/http/response/HttpResponseTest.java
@@ -1,10 +1,9 @@
-package webserver.http;
+package webserver.http.response;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import webserver.http.response.HttpResponse;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;

--- a/src/test/java/webserver/http/response/HttpResponseTest.java
+++ b/src/test/java/webserver/http/response/HttpResponseTest.java
@@ -3,13 +3,13 @@ package webserver.http.response;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import webserver.http.common.ContentType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 
 class HttpResponseTest {
 
@@ -23,43 +23,27 @@ class HttpResponseTest {
         response = new HttpResponse(dos);
     }
 
-    @Test
-    @DisplayName("올바른 응답 정보가 주어졌을 때, 200 OK 응답과 올바른 헤더 및 본문이 전송되어야 한다.")
-    public void 올바른_응답_200_응답_테스트() throws IOException {
+    @ParameterizedTest(name = "[{index}] {0} with content type {1}")
+    @CsvSource({
+            "OK, JSON, 'Hello World'",
+            "BAD_REQUEST, JSON, '{\"error\":\"Bad Request\"}'",
+            "UNSUPPORTED_MEDIA_TYPE, JSON, '{\"error\":\"Unsupported Media Type\"}'"
+    })
+    @DisplayName("올바른 응답 정보가 주어졌을 때, HTTP 응답이 올바르게 전송되어야 한다.")
+    public void 올바른_응답_테스트(String statusStr, String contentTypeStr, String body) throws IOException {
         // Given
-        String body = "Hello World";
+        HttpStatusCode status = HttpStatusCode.valueOf(statusStr);
+        ContentType contentType = ContentType.valueOf(contentTypeStr);
 
         // When
-        response.sendResponse(HttpStatusCode.OK, ContentType.JSON, body.getBytes());
-
-        // Then
-        String output = baos.toString(StandardCharsets.UTF_8);
-        Assertions.assertThat(output).contains("HTTP/1.1 200 OK");
-        Assertions.assertThat(output).contains("Content-Type: application/json");
-        Assertions.assertThat(output).contains("Content-Length: " + body.getBytes().length);
-        Assertions.assertThat(output).endsWith("Hello World");
-    }
-
-    @Test
-    @DisplayName("send400() 호출 시, 400 Bad Request 응답이 전송되어야 한다.")
-    public void 응답_400_테스트() throws IOException {
-        // When
-        response.sendResponse(HttpStatusCode.BAD_REQUEST, ContentType.JSON, "Bad Request".getBytes());
-
-        // Then
-        String output = baos.toString(StandardCharsets.UTF_8);
-        Assertions.assertThat(output).contains("400 Bad Request");
-    }
-
-    @Test
-    @DisplayName("send404() 호출 시, 404 Not Found 응답이 전송되어야 한다.")
-    public void 응답_404_테스트() throws IOException {
-        // When
-        response.sendResponse(HttpStatusCode.NOT_FOUND, ContentType.JSON, "Not Found".getBytes());
+        response.sendResponse(status, contentType, body.getBytes());
 
         // Then
         String output = baos.toString();
-        Assertions.assertThat(output).contains("404 Not Found");
+        Assertions.assertThat(output).contains("HTTP/1.1 " + status.getStatusCode() + " " + status.getReasonPhrase());
+        Assertions.assertThat(output).contains("Content-Type: " + contentType.getMimeType());
+        Assertions.assertThat(output).contains("Content-Length: " + body.getBytes().length);
+        Assertions.assertThat(output).endsWith(body);
     }
 
 }

--- a/src/test/java/webserver/http/response/HttpResponseTest.java
+++ b/src/test/java/webserver/http/response/HttpResponseTest.java
@@ -1,49 +1,32 @@
 package webserver.http.response;
 
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import webserver.http.common.ContentType;
+import org.junit.jupiter.api.Test;
+import webserver.http.common.HttpHeaders;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.IOException;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class HttpResponseTest {
 
-    private HttpResponse response;
-    private ByteArrayOutputStream baos;
-
-    @BeforeEach
-    void setUp() {
-        this.baos = new ByteArrayOutputStream();
-        DataOutputStream dos = new DataOutputStream(baos);
-        response = new HttpResponse(dos);
-    }
-
-    @ParameterizedTest(name = "[{index}] {0} with content type {1}")
-    @CsvSource({
-            "OK, JSON, 'Hello World'",
-            "BAD_REQUEST, JSON, '{\"error\":\"Bad Request\"}'",
-            "UNSUPPORTED_MEDIA_TYPE, JSON, '{\"error\":\"Unsupported Media Type\"}'"
-    })
-    @DisplayName("올바른 응답 정보가 주어졌을 때, HTTP 응답이 올바르게 전송되어야 한다.")
-    public void 올바른_응답_테스트(String statusStr, String contentTypeStr, String body) throws IOException {
+    @Test
+    @DisplayName("HTTP 응답 바디가 올바르게 byte[]로 변환되어야 한다.")
+    void 올바른_객체_생성_테스트() {
         // Given
-        HttpStatusCode status = HttpStatusCode.valueOf(statusStr);
-        ContentType contentType = ContentType.valueOf(contentTypeStr);
+        StatusLine statusLine = new StatusLine(HttpStatusCode.OK);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "text/html");
+        byte[] body = "<html><body>Hello, World!</body></html>".getBytes();
 
         // When
-        response.sendResponse(status, contentType, body.getBytes());
+        HttpResponse response = new HttpResponse(statusLine, headers, body);
 
         // Then
-        String output = baos.toString();
-        Assertions.assertThat(output).contains("HTTP/1.1 " + status.getStatusCode() + " " + status.getReasonPhrase());
-        Assertions.assertThat(output).contains("Content-Type: " + contentType.getMimeType());
-        Assertions.assertThat(output).contains("Content-Length: " + body.getBytes().length);
-        Assertions.assertThat(output).endsWith(body);
+        byte[] responseBytes = response.getBytes();
+        String responseString = new String(responseBytes);
+
+        assertThat(responseString).contains("HTTP/1.1 200 OK");
+        assertThat(responseString).contains("Content-Type: text/html");
+        assertThat(responseString).contains("<html><body>Hello, World!</body></html>");
     }
 
 }

--- a/src/test/java/webserver/resolver/ResourceResolverTest.java
+++ b/src/test/java/webserver/resolver/ResourceResolverTest.java
@@ -1,7 +1,7 @@
 package webserver.resolver;
 
-import webserver.http.HttpRequest;
-import webserver.http.HttpResponse;
+import webserver.http.request.HttpRequest;
+import webserver.http.response.HttpResponse;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/webserver/resolver/ResourceResolverTest.java
+++ b/src/test/java/webserver/resolver/ResourceResolverTest.java
@@ -1,67 +1,82 @@
 package webserver.resolver;
 
-import webserver.http.request.HttpRequest;
-import webserver.http.response.HttpResponse;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import webserver.http.common.HttpHeaders;
+import webserver.http.exception.HttpException;
+import webserver.http.request.HttpRequest;
+import webserver.http.request.RequestLine;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
-import java.io.StringReader;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ResourceResolverTest {
 
     @Test
     @DisplayName("존재하는 리소스 요청이 주어졌을 때, 200 OK 응답과 파일 내용이 전송되어야 한다.")
-    public void 올바른_리소스_요청_200_응답_반환_테스트() throws Exception {
+    void 올바른_리소스_요청_200_응답_반환_테스트() {
         // Given
-        String requestStr =
-                """
-                        GET /index.html HTTP/1.1\r
-                        Host: localhost\r
-                        \r
-                        """;
-        BufferedReader br = new BufferedReader(new StringReader(requestStr));
-        HttpRequest request = new HttpRequest(br);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        DataOutputStream dos = new DataOutputStream(baos);
-        HttpResponse response = new HttpResponse(dos);
+        RequestLine requestLine = new RequestLine("GET /index.html HTTP/1.1");
+        HttpHeaders headers = new HttpHeaders();
+        HttpRequest request = new HttpRequest(requestLine, headers, "");
+        ResourceResolver resolver = new ResourceResolver(request);
 
         // When
-        ResourceResolver resolver = new ResourceResolver(request, response);
-        resolver.resolve();
+        ResolveResponse<byte[]> resolveResponse = resolver.resolve();
 
         // Then
-        String output = baos.toString();
-        Assertions.assertThat(output).contains("200 OK");
-        Assertions.assertThat(output).contains("text/html");
+        assertThat(resolveResponse.getStatusCode().toString()).contains("200 OK");
+        assertThat(resolveResponse.getHeaders().get("Content-Type")).contains("text/html");
+        assertThat(resolveResponse.getBody()).isNotEmpty();
     }
 
     @Test
-    @DisplayName("존재하지 않는 리소스 요청이 주어졌을 때, 404 Not Found 응답이 전송되어야 한다.")
-    public void 존재하지_않은_리소스_404응답_반환_테스트() throws Exception {
+    @DisplayName("존재하지 않는 리소스 요청이 주어졌을 때, 404 Not Found 예외가 발생해야 한다.")
+    void 존재하지_않은_리소스_404응답_반환_테스트() {
         // Given
-        String requestStr =
-                """
-                        GET /nonexistent.txt HTTP/1.1\r
-                        Host: localhost\r
-                        \r
-                        """;
-        BufferedReader br = new BufferedReader(new StringReader(requestStr));
-        HttpRequest request = new HttpRequest(br);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        DataOutputStream dos = new DataOutputStream(baos);
-        HttpResponse response = new HttpResponse(dos);
+        RequestLine requestLine = new RequestLine("GET /nonexistent.txt HTTP/1.1");
+        HttpHeaders headers = new HttpHeaders();
+        HttpRequest request = new HttpRequest(requestLine, headers, "");
+        ResourceResolver resolver = new ResourceResolver(request);
+
+        // When & Then
+        assertThatThrownBy(resolver::resolve)
+                .isInstanceOf(HttpException.class)
+                .hasMessageContaining("404 Not Found");
+    }
+
+    @Test
+    @DisplayName("디렉토리 요청이 주어졌을 때, 해당 디렉토리 내의 index.html 파일을 반환해야 한다.")
+    void 디렉토리_요청_테스트() {
+        // Given
+        RequestLine requestLine = new RequestLine("GET /registration HTTP/1.1");
+        HttpHeaders headers = new HttpHeaders();
+        HttpRequest request = new HttpRequest(requestLine, headers, "");
+        ResourceResolver resolver = new ResourceResolver(request);
 
         // When
-        ResourceResolver resolver = new ResourceResolver(request, response);
-        resolver.resolve();
+        ResolveResponse<byte[]> resolveResponse = resolver.resolve();
 
         // Then
-        String output = baos.toString();
-        Assertions.assertThat(output).contains("404 Not Found");
+        assertThat(resolveResponse.getStatusCode().toString()).contains("200 OK");
+        assertThat(resolveResponse.getHeaders().get("Content-Type")).contains("text/html");
+        assertThat(resolveResponse.getBody()).isNotEmpty();
     }
+
+    @Test
+    @DisplayName("디렉토리 요청이 주어졌을 때, 해당 디렉토리가 존재하지 않으면 404 Not Found 예외가 발생해야 한다.")
+    void 존재하지_않는_디렉토리_요청_404응답_반환_테스트() {
+        // Given
+        RequestLine requestLine = new RequestLine("GET /nonexistent_directory HTTP/1.1");
+        HttpHeaders headers = new HttpHeaders();
+        HttpRequest request = new HttpRequest(requestLine, headers, "");
+        ResourceResolver resolver = new ResourceResolver(request);
+
+        // When & Then
+        assertThatThrownBy(resolver::resolve)
+                .isInstanceOf(HttpException.class)
+                .hasMessageContaining("404 Not Found");
+    }
+
 
 }

--- a/src/test/java/webserver/util/ConvertorTest.java
+++ b/src/test/java/webserver/util/ConvertorTest.java
@@ -1,0 +1,59 @@
+package webserver.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ConvertorTest {
+
+    static class TestObject {
+        String name;
+        int age;
+
+        TestObject(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+    }
+
+    @Test
+    @DisplayName("문자열을 바이트 배열로 올바르게 변환되어야 한다")
+    void 문자열을_바이트배열로_변환_테스트() {
+        // given
+        String givenString = "hello";
+
+        // when
+        byte[] result = Convertor.convertToByteArray(givenString);
+
+        // then
+        assertThat(result).isEqualTo("hello".getBytes());
+    }
+
+    @Test
+    @DisplayName("바이트 배열이 그대로 반환되어야 한다")
+    void 바이트배열_그대로반환_테스트() {
+        // given
+        byte[] givenBytes = {1, 2, 3};
+
+        // when
+        byte[] result = Convertor.convertToByteArray(givenBytes);
+
+        // then
+        assertThat(result).isSameAs(givenBytes);
+    }
+
+    @Test
+    @DisplayName("사용자 정의 객체가 바이트 배열(JSON 형태)로 변환되어야 한다")
+    void 객체_JSON_바이트배열_변환_테스트() {
+        // given
+        TestObject givenObject = new TestObject("이몽룡", 25);
+
+        // when
+        byte[] result = Convertor.convertToByteArray(givenObject);
+
+        // then
+        assertThat(new String(result)).isEqualTo("{\"name\":\"이몽룡\",\"age\":25}");
+    }
+
+}

--- a/src/test/java/webserver/util/SerializerTest.java
+++ b/src/test/java/webserver/util/SerializerTest.java
@@ -1,0 +1,98 @@
+package webserver.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SerializerTest {
+
+    static class TestObject {
+        String name;
+        int age;
+
+        TestObject(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+    }
+
+    @Test
+    @DisplayName("문자열 객체가 JSON 문자열로 올바르게 변환되어야 한다")
+    void 문자열_JSON_변환_테스트() throws IllegalAccessException {
+        // given
+        String givenString = "안녕하세요\"테스트\"";
+
+        // when
+        String result = Serializer.toJson(givenString);
+
+        // then
+        assertThat(result).isEqualTo("\"안녕하세요\\\"테스트\\\"\"");
+    }
+
+    @Test
+    @DisplayName("숫자 객체가 JSON 숫자 문자열로 올바르게 변환되어야 한다")
+    void 숫자_JSON_변환_테스트() throws IllegalAccessException {
+        // given
+        int givenNumber = 123;
+
+        // when
+        String result = Serializer.toJson(givenNumber);
+
+        // then
+        assertThat(result).isEqualTo("123");
+    }
+
+    @Test
+    @DisplayName("boolean 값이 JSON 문자열로 올바르게 변환되어야 한다")
+    void boolean_JSON_변환_테스트() throws IllegalAccessException {
+        // given
+        boolean givenBoolean = true;
+
+        // when
+        String result = Serializer.toJson(givenBoolean);
+
+        // then
+        assertThat(result).isEqualTo("true");
+    }
+
+    @Test
+    @DisplayName("객체 배열이 JSON 배열 문자열로 올바르게 변환되어야 한다")
+    void 객체배열_JSON_변환_테스트() throws IllegalAccessException {
+        // given
+        String[] givenArray = {"가", "나", "다"};
+
+        // when
+        String result = Serializer.toJson(givenArray);
+
+        // then
+        assertThat(result).isEqualTo("[\"가\",\"나\",\"다\"]");
+    }
+
+    @Test
+    @DisplayName("사용자 정의 객체가 JSON 객체 문자열로 올바르게 변환되어야 한다")
+    void 사용자정의객체_JSON_변환_테스트() throws IllegalAccessException {
+        // given
+        TestObject givenObject = new TestObject("홍길동", 30);
+
+        // when
+        String result = Serializer.toJson(givenObject);
+
+        // then
+        assertThat(result).isEqualTo("{\"name\":\"홍길동\",\"age\":30}");
+    }
+
+    @Test
+    @DisplayName("null 값이 'null' 문자열로 올바르게 변환되어야 한다")
+    void null_JSON_변환_테스트() throws IllegalAccessException {
+        // given
+        Object givenNull = null;
+
+        // when
+        String result = Serializer.toJson(givenNull);
+
+        // then
+        assertThat(result).isEqualTo("null");
+    }
+
+}


### PR DESCRIPTION
## 구현 내용

어떻게 하면 여러 결과(body)에 대한 반환, 타입을 범용적으로 다룰 수 있을까? 그리고 일관되게 HttpResponse를 생성할 수 있을까? 추후에 Tomcat 대신 현 프로젝트를 spring에 이식한다면 어떤 아키텍처, 에러 핸들링, 상호작용, 확정성 등 이런 사항들에 대해 고민을 하다보니 변경점이 많아졌습니다

- **HTTP Request/Response**
    - `ABNFRequestParser`
        - RFC7230 에 기재되어있는 ABNF를 참고하여 알맞게 파싱하는 로직을 구현했습니다
        - https://github.com/gladhee/be-was-neon/wiki/HTTP-ABNF
    - `RequestLIne`
        - Request Path에서 queryString을 추출하여 Map<String, String>으로 관리합니다.
- `DynamicResolver`
    - `@RequestMapping(method = "GET", path = "/create")`와 같은 어노테이션을 사용하여, 컨트롤러 메서드(Handler)를 등록하도록 하였습니다.
    - `DynamicHandler`라는 함수형 인터페이스를 정의하고, `@RequestMapping`이 붙어있는 메소드를 리플랙션을 사용하여 스캔 후 Handler 메소드들을 `Map<String, DynamicHandler> mappers` 로 관리합니다
    - 1차적으로 request의 path가 `mappers` 에 있는지 조회 후, 있으면 DynamicResolver로, 없을 경우 정적파일 서빙으로 간주하여 ResourceResolver로 분기처리 했습니다
- `ResourceResolver`
    - 정적 파일 서빙을 담당합니다
    - Request Path가 디렉토리일 경우 `디렉토리/index.html`를 자동으로 붙이게하여 편의성을 올렸습니다
- **응답 객체 통합 처리**
    - ResolveResponse<T> 제네릭 클래스를 도입하여 다양한 본문 타입(String, byte[], POJO 등)을 일관되게 처리할 수 있도록 하였습니다.
    - ResolveResponse.ok() 나 ResolveResponse.status() 정적팩토리 메소드를 이용해 쉽고 알맞게 응답을 생성할 수 있게 했습니다.
    - 응답 본문은 `instance of` 를 이용해 String, byte[], POJO를 구분하여 POJO일  경우`Converter.toJson()` 를 사용해 JSON 직렬화 수행하고 byte[]로 변환한 후, 최종 HttpResponse를 생성합니다.
- Dispatcher 중앙집중화
    - 각 Resolver 에서의 결과(`ResolveResponse<T>`)를 반환받아 Client에 전송할 HttpResponse 객체를 최종으로 빌딩합니다
    - HttpException을 통해 HTTP 상태 코드와 메시지를 포함하는 예외 처리를 구현하였으며 예외 발생 시 `ResolveResponse.status()`를 이용해 일관된 에러 응답(예: 404, 409, 500 등)을 반환하도록 하였습니다.

## 고민 사항

구조를 전면적으로 개산을 하다보니 테스트코드에 대한 관리가 너무 힘들었던 거 같습니다. 
사실 구조가 계속 바뀐다는 것도한 문제이지만 자주 바뀌는 상황에서 테스트코드를 어떻게 작성해나가며 관리를 해야할지에 대해 아직 감이 잘 안 옵니다

Dispatcher 이후 Resolver 의 응답이 byte[], String, Object 등 여러 타입이 나올 수 있다고 생각을 했습니다. 각 타입마다 대응하는 Dto를 작성하기보다는 제네릭 타입을 이용해 해결하는 것이 더 관리하기가 용이하다고 생각을 해서 

```java
public class ResolveResponse<T> {

    private final HttpStatusCode statusCode;
    private final HttpHeaders headers;
    private final T body;
    
    [..]
}
```

해당 객체를 만들었습니다. 하지만 여러 T의 반환을 받아야하다보니 `ResolverResponse<?> response = Resolver.resolve();`  형태로 와일드카드를 사용하게 되었습니다. 와일드카드 사용은 흔히 가독성을 헤친다고 많이 알고있어서 이에 차라리 인터페이스나 추상클래스로 여러 타입을 받는것이 더 나은지 궁금합니다.

동적 처리 요청을 하기 위한 Handler 객체 내부에 있는 메소드를 리플렉션을 이용해 가져오고 해당 메소드를 DynamicHandler 라는 함수 인터페이스에 담아서 관리를 하고 있습니다

```java
  private DynamicHandler createDynamicHandler(MethodHandle methodHandle) {
      return (request) -> {
          try {
              return (ResolveResponse<?>) methodHandle.invoke(request);
          } catch (Throwable t) {
              if (t instanceof HttpException) {
                  throw (HttpException) t;
              }

              throw new HttpException(INTERNAL_SERVER_ERROR);
          }
      };
  }
```

동적 요청을 처리하는 것은 Webserver(Tomcat)이 하는 일이 아니라고 생각을 했고, 이를 처리하는 제공받는 유저에게 어느정도 자유도를 주기 위해서 리플렉션을 단행했습니다. 사실 스프링에 이식할려면…? 이라는 생각을 주로 했습니다. 이렇게 인터페이스에 담았을 때 동적 요청 실행 당 리플렉션이 일어나게 됩니다. 찾아보니 Mehodhandle이라는 객체에 `lookup()`을 이용하면 캐싱이 된다고는 하지만 과연 이게 최선일까? 라는 궁금증이 있습니다.


## 기타

<img width="668" alt="Screenshot 2025-04-15 at 11 53 48 AM" src="https://github.com/user-attachments/assets/0c5fed66-c1a4-484d-964d-98db95acbe04" />
