### PR TITLE
[지토] step7-2 웹 서버 2단계 - 다양한 컨텐츠 타입 지원

### DIFF
--- a/src/main/java/webserver/ContentType.java
+++ b/src/main/java/webserver/ContentType.java
@@ -1,0 +1,9 @@
+package webserver;
+
+public class ContentType {
+
+    public String getContentType(){
+        String type = "";
+        return type;
+    }
+}

--- a/src/main/java/webserver/ContentType.java
+++ b/src/main/java/webserver/ContentType.java
@@ -1,9 +1,49 @@
 package webserver;
 
-public class ContentType {
+public enum ContentType {
 
-    public String getContentType(){
-        String type = "";
-        return type;
+    HTML("html", "text/html;charset=utf-8"),
+    CSS("css", "text/css;charset=utf-8"),
+    JS("js", "application/javascript"),
+    PNG("png", "image/png"),
+    JPG("jpg", "image/jpeg"),
+    JPEG("jpeg", "image/jpeg"),
+    ICO("ico", "image/x-icon"),
+    SVG("svg", "image/svg+xml");
+
+    private final String extension;
+    private final String mimeType;
+
+    ContentType(String extension, String mimeType){
+        this.extension = extension;
+        this.mimeType = mimeType;
     }
+
+    public String getExtension(){
+        return extension;
+    }
+
+    public String getMimeType(){
+        return mimeType;
+    }
+
+    public static String getContentType(String fileName){ //image.png
+        //. 이 파일명에서 마지막으로 등장한 위치를 찾는다
+        int dotIndex = fileName.lastIndexOf('.');
+        //확장자가 존재하는지 검사 -> .이 존재하고 .다음에 글자가 있어야 함
+        if(dotIndex != -1 && dotIndex < fileName.length()-1){
+            //fileName에서 파일 확장자 찾기
+            String extension = fileName.substring(dotIndex+1).toLowerCase();
+            for(ContentType contentType : ContentType.values()){
+                if(contentType.getExtension().equals(extension)){
+                    return contentType.getMimeType();
+                }
+            }
+        }
+        return  "application/octet-stream"; // 기본값 반환
+    }
+
+
+
+
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -2,7 +2,7 @@ package webserver;
 
 import java.io.*;
 import java.net.Socket;
-import java.nio.file.Files;
+
 import java.util.HashMap;
 
 import org.slf4j.Logger;
@@ -53,13 +53,30 @@ public class RequestHandler implements Runnable { //
 
             File f = new File(url);
 
-            byte[] body = Files.readAllBytes(f.toPath());
+            byte[] body = readFileToByteArray(f);
             String contentType = ContentType.getContentType(file);
             response200Header(dos, body.length, contentType); // body 값
             responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
+    }
+    //자바의 정석 - FileInputStream 공부
+    private byte[] readFileToByteArray(File file) throws IOException {
+        //파일을 읽어서 바이트 배열로 만들때 사용 : 바이트 데이터를 메모리의 바이트 배열로 저장할 수 있는 출력 스트림
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        //FileInputStream으로 파일 열기
+        FileInputStream fis = new FileInputStream(file);
+
+        //1024 바이트(1KB)씩 읽고 ByteArrayOutputStream에 저장
+        byte[] buffer = new byte[1024];
+        int bytesRead;
+        while ((bytesRead = fis.read(buffer)) != -1) {
+            baos.write(buffer, 0, bytesRead);
+        }
+
+        fis.close(); // 또는 try-with-resources로 처리 가능
+        return baos.toByteArray();
     }
 
     private void loggerParser(String line, HashMap<String, String> map, String type) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -2,6 +2,7 @@ package webserver;
 
 import java.io.*;
 import java.net.Socket;
+import java.nio.file.Files;
 import java.util.HashMap;
 
 import org.slf4j.Logger;
@@ -50,18 +51,11 @@ public class RequestHandler implements Runnable { //
             String url = "C:\\CodeSquad-Project-WebServer\\be-was-neon\\src\\main\\resources\\static"; // "src/main/resources/static"
             url += file;
 
-            br = new BufferedReader(new FileReader(url));
-            String content = "";
-            while(true){
-                String l = br.readLine();
-                content += l;
-                if(l == null) break;
-            }
+            File f = new File(url);
 
-            //index.html의 경로에 있는 내용들을 body에 담아주기
-            byte[] body = content.getBytes();
-            String contentType = "";
-            response200Header(dos, body.length, contentType);
+            byte[] body = Files.readAllBytes(f.toPath());
+            String contentType = ContentType.getContentType(file);
+            response200Header(dos, body.length, contentType); // body 값
             responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
@@ -91,7 +85,6 @@ public class RequestHandler implements Runnable { //
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
             dos.writeBytes("Content-Type: "+ contentType+"\r\n");
-            //dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -66,9 +66,9 @@ public class RequestHandler implements Runnable { //
 
         if(type.equals("requestLine")){
             String[] request_strs = line.split(" ");
-            map.put("METHOD",request_strs[0]);
-            map.put("Directory and FileName",request_strs[1]);
-            map.put("Protocol Version", request_strs[2]);
+            map.put("method",request_strs[0]);
+            map.put("path",request_strs[1]);
+            map.put("version", request_strs[2]);
         }
         else if(type.equals("header")){
             String[] header_strs = line.split(": ");

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -60,7 +60,8 @@ public class RequestHandler implements Runnable { //
 
             //index.html의 경로에 있는 내용들을 body에 담아주기
             byte[] body = content.getBytes();
-            response200Header(dos, body.length);
+            String contentType = "";
+            response200Header(dos, body.length, contentType);
             responseBody(dos, body);
         } catch (IOException e) {
             logger.error(e.getMessage());
@@ -86,10 +87,11 @@ public class RequestHandler implements Runnable { //
         }
     }
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
+    private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String contentType) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Content-Type: "+ contentType+"\r\n");
+            //dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {


### PR DESCRIPTION
## 구현 내용
1. 웹 서버에서 정적 컨텐츠들을 지원하도록 구현한다

## 고민 사항
1. MIME 타입에 대해서 공부하였고, 원래는 if문으로 구현하였으나 코드가 비효율적이라고 생각하였습니다. 그래서 가독성을 높이고 값이 고정된 한정된 값들 중 하나를 선택하는 enum 타입으로 구현하였습니다. 
📌노션 링크 : https://apple-pineapple-fa9.notion.site/MIME-1d27afc044e9807094f8e022f62ef5c3?pvs=73

2. BufferedReader를 사용하여 index.html 파일을 읽어왔는데, .svg 형식의 데이터를 읽어오지 못하는 문제가 발생하였습니다. 그래서 File 객체를 선언하여 이를` Files.readAllBytes(Path path) `메서드를 사용해서 byte 배열로 한번에 읽어와서 문제를 해결하였습니다.

` Files.readAllBytes(Path path) `메서드 : 텍스트 파일이나 이미지 파일 전체를 메모리로 한 번에 불러와야 할 때 사용한다!

3. 7-1 단계에서 피드백 받은 key 값들을 간단한 용어로 바꾸었습니다
map.put("**method**",request_strs[0]); 
            map.put("**path**",request_strs[1]);
            map.put("**version**", request_strs[2]);
4. HTTP Response에 대해 공부하였습니다.
📌노션 링크 : https://apple-pineapple-fa9.notion.site/HTTP-Response-1d27afc044e980688efbd656b55498d4?pvs=73
## 기타

