### PR TITLE
[Elbin] step-2 웹 서버 2단계 - 다양한 컨텐츠 타입 지원

### DIFF
--- a/src/main/java/webserver/ContentTypeMapper.java
+++ b/src/main/java/webserver/ContentTypeMapper.java
@@ -19,7 +19,7 @@ public class ContentTypeMapper {
     );
 
     public static String getContentType(String contentType) {
-        return contentTypeMap.get(contentType);
+        return contentTypeMap.getOrDefault(contentType, "application/octet-stream");
     }
 
 }

--- a/src/main/java/webserver/ContentTypeMapper.java
+++ b/src/main/java/webserver/ContentTypeMapper.java
@@ -6,7 +6,7 @@ import java.util.Map;
 public class ContentTypeMapper {
 
     private static final Map<String, String> contentTypeMap = Map.of(
-            ".html", "text/html; charset=utf-8",
+            ".html", "text/html;charset=utf-8",
             ".css", "text/css",
             ".js", "application/javascript",
             ".ico", "image/x-icon",

--- a/src/main/java/webserver/ContentTypeMapper.java
+++ b/src/main/java/webserver/ContentTypeMapper.java
@@ -1,0 +1,25 @@
+package webserver;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ContentTypeMapper {
+
+    private static final Map<String, String> contentTypeMap = Map.of(
+            ".html", "text/html; charset=utf-8",
+            ".css", "text/css",
+            ".js", "application/javascript",
+            ".ico", "image/x-icon",
+            ".png", "image/png",
+            ".jpg", "image/jpeg",
+            ".jpeg", "image/jpeg",
+            ".svg", "image/svg+xml",
+            ".json", "application/json",
+            ".txt", "text/plain"
+    );
+
+    public static String getContentType(String contentType) {
+        return contentTypeMap.get(contentType);
+    }
+
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -35,16 +35,20 @@ public class RequestHandler implements Runnable {
             DataOutputStream dos = new DataOutputStream(out);
 
             // 정적 파일 경로 설정 (예: index.html)
-            File file = new File("src/main/resources/static" + tokens[1]);
+            String url = tokens[1];
+            String extension = url.substring(url.lastIndexOf("."));
+            File file = new File("src/main/resources/static" + url);
             byte[] body = Files.readAllBytes(file.toPath());
-            response200Header(dos, body.length);
+
+            response200Header(dos, extension, body.length);
             responseBody(dos, body);
+
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
     }
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
+    private void response200Header(DataOutputStream dos, String extension, int lengthOfBodyContent) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
             dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -50,8 +50,9 @@ public class RequestHandler implements Runnable {
 
     private void response200Header(DataOutputStream dos, String extension, int lengthOfBodyContent) {
         try {
+            String contentType = ContentTypeMapper.getContentType(extension);
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Content-Type: " + contentType + "\r\n");
             dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {


### PR DESCRIPTION
## 구현 내용
Http request에서 보낸 다양한 컨텐츠 타입에 지원할 수 있게 적절한 Http response를 생성해주는 기능을 구현하였습니다.

## 기타
그룹 세션을 진행하면서 http request header 정보를 파싱을 담당하는 객체가 필요할 것이다라는 말이 나왔는데 저는 구현하면서 해당 단계에선 필요할 거 같지 않다고 생각하여 구현하지 않았습니다. http request header 정보를 파싱의 필요성이 느껴지면 그 때 해당 객체를 구현할 수 있도록 하겠습니다.
존재하지 않는 페이지나 루트 경로로 접근했을 때 페이지 처리를 하지 않았습니다. 해당 부분은 단계를 거치면서 추가하도록 하겠습니다. 


