### PR TITLE
[Glad] Step 8-2  웹 서버 5단계 - 쿠키를 이용한 로그인

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,20 @@
 - 기존 회원가입 기능을 POST 방식으로 변경
 - 가입 이후 `http://localhost:8080/index.html`으로 리다이렉트
 - GET 으로 회원가입 시도시 **실패**해야함
+
+## 5. 쿠키를 이용한 로그인
+
+### 로그인 기능 구현
+
+- `http://localhost:8080/login/index.html` 접속시 로그인 폼을 응답
+- Request parameter로 `userId`, `password`를 받음
+
+### 로그인 성공시
+
+- `http://localhost:8080/index.html`으로 리다이렉트
+- 로그인 성공시 `Set-Cookie` 헤더를 이용하여 쿠키를 저장
+- 
+
+### 로그인 실패시
+
+- `http://localhost:8080/login/login_failed.html`으로 리다이렉트

--- a/src/main/java/handler/Handler.java
+++ b/src/main/java/handler/Handler.java
@@ -57,15 +57,14 @@ public class Handler {
         Map<String, String> queryString = QueryStringParser.parse(body);
         String userId = queryString.get("userId");
         String password = queryString.get("password");
-        validateNotBlank(userId, password);
         User user = Database.findUserById(userId);
         if (user == null) {
             logger.debug("User not found: {}", userId);
-            throw new HttpException(BAD_REQUEST);
+            return ResolveResponse.redirect("/login/login_failed.html");
         }
         if (!user.getPassword().equals(password)) {
             logger.debug("Invalid password for user: {}", userId);
-            throw new HttpException(BAD_REQUEST);
+            return ResolveResponse.redirect("/login/login_failed.html");
         }
         session.setAttribute("user", user);
         logger.debug("User logged in: {}", user);

--- a/src/main/java/handler/Handler.java
+++ b/src/main/java/handler/Handler.java
@@ -44,7 +44,7 @@ public class Handler {
             throw new HttpException(CONFLICT);
         }
 
-        User user = new User(userId, name, password, email);
+        User user = new User(userId, password, name, email);
         Database.addUser(user);
         logger.debug("User created: {}", user);
         return ResolveResponse.redirect("/");

--- a/src/main/java/handler/Handler.java
+++ b/src/main/java/handler/Handler.java
@@ -1,19 +1,17 @@
 package handler;
 
-import webserver.annotation.RequestMapping;
 import db.Database;
 import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import webserver.http.common.ContentType;
+import webserver.annotation.RequestMapping;
+import webserver.http.common.HttpSession;
 import webserver.http.exception.HttpException;
 import webserver.http.request.HttpRequest;
 import webserver.resolver.ResolveResponse;
 import webserver.util.QueryStringParser;
 
-import java.util.Arrays;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static webserver.http.response.HttpStatusCode.BAD_REQUEST;
 import static webserver.http.response.HttpStatusCode.CONFLICT;
@@ -49,6 +47,28 @@ public class Handler {
         User user = new User(userId, name, password, email);
         Database.addUser(user);
         logger.debug("User created: {}", user);
+        return ResolveResponse.redirect("/");
+    }
+
+    @RequestMapping(method = "POST", path = "/login")
+    public ResolveResponse<String> login(HttpRequest request, HttpSession session) {
+        logger.debug("getLogin");
+        String body = request.getBody();
+        Map<String, String> queryString = QueryStringParser.parse(body);
+        String userId = queryString.get("userId");
+        String password = queryString.get("password");
+        validateNotBlank(userId, password);
+        User user = Database.findUserById(userId);
+        if (user == null) {
+            logger.debug("User not found: {}", userId);
+            throw new HttpException(BAD_REQUEST);
+        }
+        if (!user.getPassword().equals(password)) {
+            logger.debug("Invalid password for user: {}", userId);
+            throw new HttpException(BAD_REQUEST);
+        }
+        session.setAttribute("user", user);
+        logger.debug("User logged in: {}", user);
         return ResolveResponse.redirect("/");
     }
 

--- a/src/main/java/webserver/Dispatcher.java
+++ b/src/main/java/webserver/Dispatcher.java
@@ -2,6 +2,8 @@ package webserver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.http.common.CookieShop;
+import webserver.http.common.HttpHeaders;
 import webserver.http.common.HttpMethod;
 import webserver.http.exception.HttpException;
 import webserver.http.request.HttpRequest;
@@ -27,6 +29,7 @@ public class Dispatcher {
         try {
             ResolveResponse<?> resolveResponse = resolver.resolve();
 
+            addSessionCookieIfNew(resolveResponse);
             return buildHttpResponse(resolveResponse);
         } catch (HttpException e) {
             logger.error("Error during request processing: {}", e.getMessage());
@@ -48,6 +51,13 @@ public class Dispatcher {
 
         logger.debug("Dispatching to DynamicResolver");
         return new DynamicResolver(request, handler);
+    }
+
+    private void addSessionCookieIfNew(ResolveResponse<?> resolveResponse) {
+        if (request.isNewSession()) {
+            HttpHeaders headers = resolveResponse.getHeaders();
+            headers.addCookie(request.getSessionId());
+        }
     }
 
     private HttpResponse buildHttpResponse(ResolveResponse<?> responseEntity) {

--- a/src/main/java/webserver/Dispatcher.java
+++ b/src/main/java/webserver/Dispatcher.java
@@ -2,8 +2,6 @@ package webserver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import webserver.http.common.CookieShop;
-import webserver.http.common.HttpHeaders;
 import webserver.http.common.HttpMethod;
 import webserver.http.exception.HttpException;
 import webserver.http.request.HttpRequest;
@@ -29,7 +27,7 @@ public class Dispatcher {
         try {
             ResolveResponse<?> resolveResponse = resolver.resolve();
 
-            addSessionCookieIfNew(resolveResponse);
+            SessionResolver.addSessionCookieIfNew(request, resolveResponse);
             return buildHttpResponse(resolveResponse);
         } catch (HttpException e) {
             logger.error("Error during request processing: {}", e.getMessage());
@@ -51,13 +49,6 @@ public class Dispatcher {
 
         logger.debug("Dispatching to DynamicResolver");
         return new DynamicResolver(request, handler);
-    }
-
-    private void addSessionCookieIfNew(ResolveResponse<?> resolveResponse) {
-        if (request.isNewSession()) {
-            HttpHeaders headers = resolveResponse.getHeaders();
-            headers.addCookie(request.getSessionId());
-        }
     }
 
     private HttpResponse buildHttpResponse(ResolveResponse<?> responseEntity) {

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -7,6 +7,7 @@ import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.mapper.HandlerMapper;
 
 public class WebServer {
     private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
@@ -20,6 +21,7 @@ public class WebServer {
             port = Integer.parseInt(args[0]);
         }
 
+        HandlerMapper.getInstance();
         ExecutorService executor = Executors.newFixedThreadPool(10);
 
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -21,7 +21,9 @@ public class WebServer {
             port = Integer.parseInt(args[0]);
         }
 
-        HandlerMapper.getInstance();
+
+        HandlerMapper handlerMapper = HandlerMapper.getInstance();
+        handlerMapper.initialize();
         ExecutorService executor = Executors.newFixedThreadPool(10);
 
         // 서버소켓을 생성한다. 웹서버는 기본적으로 8080번 포트를 사용한다.

--- a/src/main/java/webserver/http/common/CookieShop.java
+++ b/src/main/java/webserver/http/common/CookieShop.java
@@ -1,0 +1,38 @@
+package webserver.http.common;
+
+import static webserver.http.common.HttpConstants.EQUALS;
+
+public class CookieShop {
+
+    private static final String SESSION_COOKIE_NAME = "JSESSIONID";
+    private static final String COOKIE = "Cookie";
+    private static final String SEMICOLON = ";";
+    private static final String HTTP_ONLY = "HttpOnly";
+    private static final String PATH = "Path=";
+    private static final String ALLOWED_PATH = "/";
+
+
+    public static String takeSessionIdFrom(HttpHeaders headers) {
+        String rawCookie = headers.get(COOKIE);
+        if (rawCookie == null) {
+            return null;
+        }
+
+        String[] cookies = rawCookie.split(SEMICOLON);
+        for (String cookie : cookies) {
+            String[] keyValue = cookie.split(EQUALS);
+            if (keyValue.length == 2 && keyValue[0].trim().equals(SESSION_COOKIE_NAME)) {
+                return keyValue[1].trim();
+            }
+        }
+
+        return null;
+    }
+
+    public static String bakeSessionCookie(String sessionId) {
+        return SESSION_COOKIE_NAME + EQUALS + sessionId + SEMICOLON
+                + PATH + ALLOWED_PATH + SEMICOLON
+                + HTTP_ONLY;
+    }
+
+}

--- a/src/main/java/webserver/http/common/HttpHeaders.java
+++ b/src/main/java/webserver/http/common/HttpHeaders.java
@@ -11,6 +11,7 @@ public class HttpHeaders {
     private static final Logger logger = LoggerFactory.getLogger(HttpHeaders.class.getName());
     private static final String CONTENT_TYPE = "Content-Type";
     private static final String LOCATION = "Location";
+    private static final String SET_COOKIE = "Set-Cookie";
     private final Map<String, String> headers;
 
     public HttpHeaders() {
@@ -27,6 +28,12 @@ public class HttpHeaders {
 
     public void addLocation(String location) {
         headers.put(LOCATION, location);
+    }
+
+    public void addCookie(String sessionId) {
+        String cookie = CookieShop.bakeSessionCookie(sessionId);
+        logger.debug("Add cookie to session: {}", cookie);
+        headers.put(SET_COOKIE, cookie);
     }
 
     public boolean containsKey(String key) {

--- a/src/main/java/webserver/http/common/HttpHeaders.java
+++ b/src/main/java/webserver/http/common/HttpHeaders.java
@@ -2,7 +2,6 @@ package webserver.http.common;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import webserver.http.exception.HeaderNotFoundException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +36,7 @@ public class HttpHeaders {
     public String get(String fieldName) {
         if (!headers.containsKey(fieldName)) {
             logger.error("Header에 {}이 존재하지않습니다.", fieldName);
-            throw new HeaderNotFoundException("Header에 " + fieldName + "이 존재하지않습니다.");
+            return null;
         }
 
         return headers.get(fieldName);

--- a/src/main/java/webserver/http/common/HttpSession.java
+++ b/src/main/java/webserver/http/common/HttpSession.java
@@ -1,5 +1,7 @@
 package webserver.http.common;
 
+import webserver.session.SessionManager;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,6 +29,7 @@ public class HttpSession {
 
     public void invalidate() {
         attributes.clear();
+        SessionManager.getInstance().removeSession(id);
     }
 
     public String getId() {

--- a/src/main/java/webserver/http/common/HttpSession.java
+++ b/src/main/java/webserver/http/common/HttpSession.java
@@ -1,0 +1,36 @@
+package webserver.http.common;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpSession {
+
+    private final String id;
+    private final Map<String, Object> attributes;
+
+    public HttpSession(String id) {
+        this.id = id;
+        this.attributes = new HashMap<>();
+    }
+
+    public void setAttribute(String name, Object value) {
+        attributes.put(name, value);
+    }
+
+    public Object getAttribute(String name) {
+        return attributes.get(name);
+    }
+
+    public void removeAttribute(String name) {
+        attributes.remove(name);
+    }
+
+    public void invalidate() {
+        attributes.clear();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+}

--- a/src/main/java/webserver/http/exception/HeaderNotFoundException.java
+++ b/src/main/java/webserver/http/exception/HeaderNotFoundException.java
@@ -1,7 +1,0 @@
-package webserver.http.exception;
-
-public class HeaderNotFoundException extends RuntimeException {
-    public HeaderNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/webserver/http/request/HttpRequest.java
+++ b/src/main/java/webserver/http/request/HttpRequest.java
@@ -1,10 +1,8 @@
 package webserver.http.request;
 
-import webserver.http.common.CookieShop;
 import webserver.http.common.HttpHeaders;
 import webserver.http.common.HttpMethod;
 import webserver.http.common.HttpSession;
-import webserver.session.SessionManager;
 
 public class HttpRequest {
 
@@ -38,19 +36,7 @@ public class HttpRequest {
         return headers;
     }
 
-    public HttpSession getOrCreateSession() {
-        if (this.session != null) {
-            return session;
-        }
-
-        String sessionId = CookieShop.takeSessionIdFrom(headers);
-        if (sessionId == null) {
-            isNewSession = true;
-        }
-
-        SessionManager sessionManager = SessionManager.getInstance();
-        session = sessionManager.getOrCreateSession(sessionId);
-
+    public HttpSession getSession() {
         return session;
     }
 
@@ -64,6 +50,11 @@ public class HttpRequest {
 
     public boolean isNewSession() {
         return isNewSession;
+    }
+
+    public void setSession(HttpSession session, boolean isNew) {
+        this.session = session;
+        this.isNewSession = isNew;
     }
 
     @Override

--- a/src/main/java/webserver/http/request/HttpRequest.java
+++ b/src/main/java/webserver/http/request/HttpRequest.java
@@ -1,7 +1,10 @@
 package webserver.http.request;
 
+import webserver.http.common.CookieShop;
 import webserver.http.common.HttpHeaders;
 import webserver.http.common.HttpMethod;
+import webserver.http.common.HttpSession;
+import webserver.session.SessionManager;
 
 public class HttpRequest {
 
@@ -29,6 +32,13 @@ public class HttpRequest {
 
     public HttpHeaders getHeaders() {
         return headers;
+    }
+
+    public HttpSession getOrCreateSession() {
+        String sessionId = CookieShop.takeSessionIdFrom(headers);
+
+        SessionManager sessionManager = SessionManager.getInstance();
+        return sessionManager.getOrCreateSession(sessionId);
     }
 
     public String getBody() {

--- a/src/main/java/webserver/http/request/HttpRequest.java
+++ b/src/main/java/webserver/http/request/HttpRequest.java
@@ -11,11 +11,15 @@ public class HttpRequest {
     private final RequestLine requestLine;
     private final HttpHeaders headers;
     private final String body;
+    private HttpSession session;
+    private boolean isNewSession;
 
     public HttpRequest(RequestLine requestLine, HttpHeaders headers, String body) {
         this.requestLine = requestLine;
         this.headers = headers;
         this.body = body;
+        this.session = null;
+        this.isNewSession = false;
     }
 
     public RequestLine getRequestLine() {
@@ -35,14 +39,31 @@ public class HttpRequest {
     }
 
     public HttpSession getOrCreateSession() {
+        if (this.session != null) {
+            return session;
+        }
+
         String sessionId = CookieShop.takeSessionIdFrom(headers);
+        if (sessionId == null) {
+            isNewSession = true;
+        }
 
         SessionManager sessionManager = SessionManager.getInstance();
-        return sessionManager.getOrCreateSession(sessionId);
+        session = sessionManager.getOrCreateSession(sessionId);
+
+        return session;
     }
 
     public String getBody() {
         return body;
+    }
+
+    public String getSessionId() {
+        return session.getId();
+    }
+
+    public boolean isNewSession() {
+        return isNewSession;
     }
 
     @Override

--- a/src/main/java/webserver/mapper/HandlerMapper.java
+++ b/src/main/java/webserver/mapper/HandlerMapper.java
@@ -23,18 +23,20 @@ public class HandlerMapper {
 
     private static final HandlerMapper instance = new HandlerMapper();
     // 잦은 리플렉션 사용으로 성능 저하를 방지하기 위해 MethodHandles.Lookup을 사용
-    private final MethodHandles.Lookup lookup = MethodHandles.lookup();
+    private final MethodHandles.Lookup lookup;
     private final Map<String, DynamicHandler> mappings;
 
     private HandlerMapper() {
         this.mappings = new HashMap<>();
-
-        // 컨트롤러 등록
-        registerController(Handler.getInstance());
+        this.lookup = MethodHandles.lookup();
     }
 
     public static HandlerMapper getInstance() {
         return instance;
+    }
+
+    public void initialize() {
+        registerController(Handler.getInstance());
     }
 
     private void registerController(Object controller) {

--- a/src/main/java/webserver/mapper/HandlerMapper.java
+++ b/src/main/java/webserver/mapper/HandlerMapper.java
@@ -8,6 +8,7 @@ import webserver.http.exception.HttpException;
 import webserver.http.request.HttpRequest;
 import webserver.resolver.DynamicHandler;
 import webserver.resolver.ResolveResponse;
+import webserver.resolver.SessionResolver;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -96,7 +97,8 @@ public class HandlerMapper {
             }
 
             if (paramTypes[i] == HttpSession.class) {
-                args[i] = request.getOrCreateSession();
+                SessionResolver.injectSession(request);
+                args[i] = request.getSession();
             }
         }
 

--- a/src/main/java/webserver/mapper/HandlerMapper.java
+++ b/src/main/java/webserver/mapper/HandlerMapper.java
@@ -47,6 +47,7 @@ public class HandlerMapper {
 
     private void registerMapping(Object controller, Method method) {
         RequestMapping mapping = method.getAnnotation(RequestMapping.class);
+        validateSignature(method);
         String key = mapping.method() + SPACE + mapping.path();
 
         try {
@@ -55,6 +56,17 @@ public class HandlerMapper {
             mappings.put(key, handler);
         } catch (IllegalAccessException e) {
             throw new HttpException(INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private void validateSignature(Method method) {
+        for (Class<?> p : method.getParameterTypes()) {
+            if (p != HttpRequest.class && p != HttpSession.class) {
+                throw new IllegalStateException(
+                        "[ERROR] 지원하지 않는 파라미터 타입: "
+                                + method.getName() + " -> " + p.getSimpleName()
+                );
+            }
         }
     }
 

--- a/src/main/java/webserver/mapper/HandlerMapper.java
+++ b/src/main/java/webserver/mapper/HandlerMapper.java
@@ -1,15 +1,16 @@
 package webserver.mapper;
 
-import webserver.annotation.RequestMapping;
 import handler.Handler;
+import webserver.annotation.RequestMapping;
 import webserver.http.common.HttpMethod;
+import webserver.http.common.HttpSession;
 import webserver.http.exception.HttpException;
+import webserver.http.request.HttpRequest;
 import webserver.resolver.DynamicHandler;
 import webserver.resolver.ResolveResponse;
 
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
@@ -50,17 +51,18 @@ public class HandlerMapper {
 
         try {
             MethodHandle methodHandle = lookup.unreflect(method).bindTo(controller);
-            DynamicHandler handler = createDynamicHandler(methodHandle);
+            DynamicHandler handler = createDynamicHandler(method, methodHandle);
             mappings.put(key, handler);
         } catch (IllegalAccessException e) {
             throw new HttpException(INTERNAL_SERVER_ERROR);
         }
     }
 
-    private DynamicHandler createDynamicHandler(MethodHandle methodHandle) {
+    private DynamicHandler createDynamicHandler(Method method, MethodHandle methodHandle) {
         return (request) -> {
+            Object[] args = buildArguments(method, request);
             try {
-                return (ResolveResponse<?>) methodHandle.invoke(request);
+                return (ResolveResponse<?>) methodHandle.invokeWithArguments(args);
             } catch (Throwable t) {
                 if (t instanceof HttpException) {
                     throw (HttpException) t;
@@ -69,6 +71,24 @@ public class HandlerMapper {
                 throw new HttpException(INTERNAL_SERVER_ERROR);
             }
         };
+    }
+
+    private Object[] buildArguments(Method method, HttpRequest request) {
+        Class<?>[] paramTypes = method.getParameterTypes();
+        Object[] args = new Object[paramTypes.length];
+
+        for (int i = 0; i < paramTypes.length; i++) {
+            if (paramTypes[i] == HttpRequest.class) {
+                args[i] = request;
+                continue;
+            }
+
+            if (paramTypes[i] == HttpSession.class) {
+                args[i] = request.getOrCreateSession();
+            }
+        }
+
+        return args;
     }
 
     public DynamicHandler getHandler(HttpMethod method, String path) {

--- a/src/main/java/webserver/resolver/SessionResolver.java
+++ b/src/main/java/webserver/resolver/SessionResolver.java
@@ -1,0 +1,35 @@
+package webserver.resolver;
+
+import webserver.http.common.CookieShop;
+import webserver.http.common.HttpHeaders;
+import webserver.http.common.HttpSession;
+import webserver.http.request.HttpRequest;
+import webserver.session.SessionManager;
+
+public class SessionResolver {
+
+    private static final SessionManager sessionManager = SessionManager.getInstance();
+
+    private SessionResolver() {
+    }
+
+    public static void injectSession(HttpRequest request) {
+        HttpHeaders headers = request.getHeaders();
+        String sid = CookieShop.takeSessionIdFrom(headers);
+        boolean isNew = (sid == null);
+
+        HttpSession session = sessionManager.getOrCreateSession(sid);
+        request.setSession(session, isNew);
+    }
+
+    public static void addSessionCookieIfNew(HttpRequest request, ResolveResponse<?> resolveResponse) {
+        if (!request.isNewSession()) {
+            return;
+        }
+
+        HttpHeaders headers = resolveResponse.getHeaders();
+        String sessionId = request.getSessionId();
+        headers.addCookie(sessionId);
+    }
+
+}

--- a/src/main/java/webserver/session/SessionManager.java
+++ b/src/main/java/webserver/session/SessionManager.java
@@ -1,0 +1,43 @@
+package webserver.session;
+
+import webserver.http.common.HttpSession;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SessionManager {
+
+    private static final SessionManager instance = new SessionManager();
+    private static final SecureRandom random = new SecureRandom();
+    private static final int SESSION_ID_LENGTH = 16;
+    private static final Map<String, HttpSession> sessions = new ConcurrentHashMap<>();
+
+    private SessionManager() {
+    }
+
+    public static SessionManager getInstance() {
+        return instance;
+    }
+
+    public HttpSession getOrCreateSession(String sessionId) {
+        if (sessionId == null) {
+            sessionId = generateSessionId();
+        }
+
+        return sessions.computeIfAbsent(sessionId, HttpSession::new);
+    }
+
+    private String generateSessionId() {
+        byte[] bytes = new byte[SESSION_ID_LENGTH];
+        random.nextBytes(bytes);
+
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    public void removeSession(String sessionId) {
+        sessions.remove(sessionId);
+    }
+
+}

--- a/src/main/java/webserver/util/QueryStringParser.java
+++ b/src/main/java/webserver/util/QueryStringParser.java
@@ -12,7 +12,7 @@ public class QueryStringParser {
 
     public static Map<String, String> parse(String input) {
         Map<String, String> queryParameters = new HashMap<>();
-        if (input.isEmpty()) {
+        if (input == null || input.isEmpty()) {
             return queryParameters;
         }
 

--- a/src/main/resources/static/login/index.html
+++ b/src/main/resources/static/login/index.html
@@ -23,10 +23,10 @@
       </header>
       <div class="page">
         <h2 class="page-title">로그인</h2>
-        <form class="form">
+        <form class="form" method="POST" action="/login">
           <div class="textfield textfield_size_s">
             <p class="title_textfield">아이디</p>
-            <input
+            <input name="userId"
               class="input_textfield"
               placeholder="아이디를 입력해주세요"
               autocomplete="username"
@@ -34,7 +34,7 @@
           </div>
           <div class="textfield textfield_size_s">
             <p class="title_textfield">비밀번호</p>
-            <input
+            <input name="password"
               class="input_textfield"
               type="password"
               placeholder="비밀번호를 입력해주세요"
@@ -45,7 +45,7 @@
             id="login-btn"
             class="btn btn_contained btn_size_m"
             style="margin-top: 24px"
-            type="button"
+            type="submit"
           >
             로그인
           </button>

--- a/src/main/resources/static/login/login_failed.html
+++ b/src/main/resources/static/login/login_failed.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>로그인 실패</title>
+
+    <!-- reset & global stylesheet가 이미 프로젝트에 있다면 그대로 사용 -->
+    <link rel="stylesheet" href="../reset.css" />
+    <link rel="stylesheet" href="../global.css" />
+
+    <style>
+        body {
+            display: flex;
+            flex-direction: column;
+            min-height: 100dvh;
+            align-items: center;
+            justify-content: center;
+            font-family: "Pretendard", "Apple SD Gothic Neo", sans-serif;
+            background: #fafafa;
+        }
+
+        .error-card {
+            width: 320px;
+            padding: 32px 40px;
+            border-radius: 16px;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+            background: #ffffff;
+            text-align: center;
+        }
+
+        .error-card__title {
+            font-size: 20px;
+            font-weight: 700;
+            margin-bottom: 12px;
+        }
+
+        .error-card__message {
+            font-size: 15px;
+            color: #666;
+            line-height: 1.5;
+            margin-bottom: 24px;
+        }
+
+        .btn {
+            display: inline-block;
+            padding: 10px 20px;
+            border-radius: 8px;
+            font-size: 14px;
+            font-weight: 600;
+            text-decoration: none;
+            cursor: pointer;
+            transition: background 0.15s ease-in-out;
+        }
+        .btn_primary {
+            color: #fff;
+            background: #3a7afe;
+        }
+        .btn_primary:hover {
+            background: #296af3;
+        }
+        .btn_ghost {
+            color: #3a7afe;
+            background: transparent;
+        }
+        .btn_ghost:hover {
+            background: rgba(58, 122, 254, 0.1);
+        }
+    </style>
+</head>
+<body>
+<section class="error-card">
+    <h1 class="error-card__title">로그인 실패</h1>
+    <p class="error-card__message">
+        아이디 또는 비밀번호가 올바르지 않습니다.<br />
+        다시 시도해 주세요.
+    </p>
+
+    <a href="/login" class="btn btn_primary">로그인 화면으로</a>
+    <a href="/" class="btn btn_ghost" style="margin-left: 8px;">홈으로</a>
+</section>
+</body>
+</html>

--- a/src/test/java/handler/HandlerTest.java
+++ b/src/test/java/handler/HandlerTest.java
@@ -1,0 +1,156 @@
+package handler;
+
+import db.Database;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import webserver.http.common.HttpHeaders;
+import webserver.http.exception.HttpException;
+import webserver.http.request.HttpRequest;
+import webserver.http.request.RequestLine;
+import webserver.http.response.HttpStatusCode;
+import webserver.resolver.ResolveResponse;
+import webserver.resolver.SessionResolver;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class HandlerTest {
+
+    @BeforeEach
+    void setUp() {
+        // db 초기화 리플렉션
+        try {
+            Field usersField = Database.class.getDeclaredField("users");
+            usersField.setAccessible(true);                   // private 접근 허용
+            Map<?, ?> usersMap = (Map<?, ?>) usersField.get(null);
+            usersMap.clear();
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    @DisplayName("유저 생성 요청시 올바르게 생성 후 리다이렉션 된다")
+    void 유저_생성_테스트() {
+        // given
+        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
+        HttpHeaders headers = new HttpHeaders();
+        String body = "userId=javajigi&name=자바지기&password=password&email=javajigi%40slipp.net";
+        HttpRequest request = new HttpRequest(requestLine, headers, body);
+
+        // when
+        ResolveResponse<?> response = Handler.getInstance().createUser(request);
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatusCode.FOUND);
+        assertThat(response.getHeaders().get("Location")).isEqualTo("/");
+    }
+
+    @Test
+    @DisplayName("유저 생성 요청시 중복된 아이디로 요청하면 CONFLICT 응답을 받는다")
+    void 유저_생성_중복_예외_테스트() {
+        // given
+        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
+        HttpHeaders headers = new HttpHeaders();
+        String body = "userId=javajigi&name=자바지기&password=password&email=javajigi%40slipp.net";
+        HttpRequest request = new HttpRequest(requestLine, headers, body);
+        Handler.getInstance().createUser(request);
+
+        // when & then
+        assertThatThrownBy(() -> Handler.getInstance().createUser(request))
+                .isInstanceOf(HttpException.class)
+                .hasMessageContaining("409 Conflict");
+    }
+
+    @Test
+    @DisplayName("유저 생성 요청시 필드가 비어있으면 BAD_REQUEST 응답을 받는다")
+    void 유저_생성_필드_비어있음_예외_테스트() {
+        // given
+        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
+        HttpHeaders headers = new HttpHeaders();
+        String body = "userId=javajigi&name=&password=password&email=javajigi%40slipp.net";
+        HttpRequest request = new HttpRequest(requestLine, headers, body);
+
+        // when & then
+        assertThatThrownBy(() -> Handler.getInstance().createUser(request))
+                .isInstanceOf(HttpException.class)
+                .hasMessageContaining("400 Bad Request");
+    }
+
+    @Test
+    @DisplayName("로그인 요청시 올바르게 로그인 후 리다이렉션 된다")
+    void 정상_로그인_테스트() {
+        // given
+        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
+        HttpHeaders headers = new HttpHeaders();
+        String body = "userId=javajigi&name=자바지기&password=test&email=javajigi%40slipp.net";
+        HttpRequest request = new HttpRequest(requestLine, headers, body);
+        Handler.getInstance().createUser(request);
+
+        // when
+        RequestLine newRequestLine = new RequestLine("POST /login HTTP/1.1");
+        HttpHeaders newHeaders = new HttpHeaders();
+        newHeaders.add("Cookie", "JSESSIONID=1234567890");
+        String newBody = "userId=javajigi&password=test";
+        HttpRequest newRequest = new HttpRequest(newRequestLine, newHeaders, newBody);
+        SessionResolver.injectSession(newRequest);
+        ResolveResponse<?> response = Handler.getInstance().login(newRequest, newRequest.getSession());
+
+        // then
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatusCode.FOUND);
+        assertThat(response.getHeaders().get("Location")).isEqualTo("/");
+    }
+
+    @Test
+    @DisplayName("로그인 요청시 잘못된 비밀번호로 요청하면 BAD_REQUEST 응답을 받는다")
+    void 로그인_잘못된_비밀번호_예외_테스트() {
+        // given
+        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
+        HttpHeaders headers = new HttpHeaders();
+        String body = "userId=javajigi&name=자바지기&password=test&email=javajigi%40slipp.net";
+        HttpRequest request = new HttpRequest(requestLine, headers, body);
+        Handler.getInstance().createUser(request);
+
+        // when
+        RequestLine newRequestLine = new RequestLine("POST /login HTTP/1.1");
+        HttpHeaders newHeaders = new HttpHeaders();
+        newHeaders.add("Cookie", "JSESSIONID=1234567890");
+        String newBody = "userId=javajigi&password=wrongPassword";
+        HttpRequest newRequest = new HttpRequest(newRequestLine, newHeaders, newBody);
+        SessionResolver.injectSession(newRequest);
+
+        // then
+        assertThatThrownBy(() -> Handler.getInstance().login(newRequest, newRequest.getSession()))
+                .isInstanceOf(HttpException.class)
+                .hasMessageContaining("400 Bad Request");
+    }
+
+    @Test
+    @DisplayName("로그인 요청시 잘못된 아이디로 요청하면 BAD_REQUEST 응답을 받는다")
+    void 로그인_잘못된_아이디_예외_테스트() {
+        // given
+        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
+        HttpHeaders headers = new HttpHeaders();
+        String body = "userId=javajigi&name=자바지기&password=test&email=javajigi%40slipp.net";
+        HttpRequest request = new HttpRequest(requestLine, headers, body);
+        Handler.getInstance().createUser(request);
+
+        // when
+        RequestLine newRequestLine = new RequestLine("POST /login HTTP/1.1");
+        HttpHeaders newHeaders = new HttpHeaders();
+        newHeaders.add("Cookie", "JSESSIONID=1234567890");
+        String newBody = "userId=wrongUserId&password=test";
+        HttpRequest newRequest = new HttpRequest(newRequestLine, newHeaders, newBody);
+        SessionResolver.injectSession(newRequest);
+
+        // then
+        assertThatThrownBy(() -> Handler.getInstance().login(newRequest, newRequest.getSession()))
+                .isInstanceOf(HttpException.class)
+                .hasMessageContaining("400 Bad Request");
+    }
+
+}

--- a/src/test/java/handler/HandlerTest.java
+++ b/src/test/java/handler/HandlerTest.java
@@ -1,13 +1,13 @@
 package handler;
 
 import db.Database;
+import model.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import webserver.http.common.HttpHeaders;
+import provider.RequestBuilder;
 import webserver.http.exception.HttpException;
 import webserver.http.request.HttpRequest;
-import webserver.http.request.RequestLine;
 import webserver.http.response.HttpStatusCode;
 import webserver.resolver.ResolveResponse;
 import webserver.resolver.SessionResolver;
@@ -37,10 +37,9 @@ class HandlerTest {
     @DisplayName("유저 생성 요청시 올바르게 생성 후 리다이렉션 된다")
     void 유저_생성_테스트() {
         // given
-        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
-        HttpHeaders headers = new HttpHeaders();
-        String body = "userId=javajigi&name=자바지기&password=password&email=javajigi%40slipp.net";
-        HttpRequest request = new HttpRequest(requestLine, headers, body);
+        HttpRequest request = RequestBuilder.post("/create")
+                .body("userId=javajigi&name=자바지기&password=password&email=javajigi%40slipp.net")
+                .build();
 
         // when
         ResolveResponse<?> response = Handler.getInstance().createUser(request);
@@ -54,10 +53,9 @@ class HandlerTest {
     @DisplayName("유저 생성 요청시 중복된 아이디로 요청하면 CONFLICT 응답을 받는다")
     void 유저_생성_중복_예외_테스트() {
         // given
-        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
-        HttpHeaders headers = new HttpHeaders();
-        String body = "userId=javajigi&name=자바지기&password=password&email=javajigi%40slipp.net";
-        HttpRequest request = new HttpRequest(requestLine, headers, body);
+        HttpRequest request = RequestBuilder.post("/create")
+                        .body("userId=javajigi&name=자바지기&password=password&email=javajigi%40slipp.net")
+                        .build();
         Handler.getInstance().createUser(request);
 
         // when & then
@@ -70,10 +68,9 @@ class HandlerTest {
     @DisplayName("유저 생성 요청시 필드가 비어있으면 BAD_REQUEST 응답을 받는다")
     void 유저_생성_필드_비어있음_예외_테스트() {
         // given
-        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
-        HttpHeaders headers = new HttpHeaders();
-        String body = "userId=javajigi&name=&password=password&email=javajigi%40slipp.net";
-        HttpRequest request = new HttpRequest(requestLine, headers, body);
+        HttpRequest request = RequestBuilder.post("/create")
+                .body("userId=javajigi&name=&password=password&email=javajigi%40slipp.net")
+                .build();
 
         // when & then
         assertThatThrownBy(() -> Handler.getInstance().createUser(request))
@@ -85,20 +82,16 @@ class HandlerTest {
     @DisplayName("로그인 요청시 올바르게 로그인 후 리다이렉션 된다")
     void 정상_로그인_테스트() {
         // given
-        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
-        HttpHeaders headers = new HttpHeaders();
-        String body = "userId=javajigi&name=자바지기&password=test&email=javajigi%40slipp.net";
-        HttpRequest request = new HttpRequest(requestLine, headers, body);
-        Handler.getInstance().createUser(request);
+        User user = new User("javajigi", "test", "자바지기", "javajigi@naver.com");
+        Database.addUser(user);
 
         // when
-        RequestLine newRequestLine = new RequestLine("POST /login HTTP/1.1");
-        HttpHeaders newHeaders = new HttpHeaders();
-        newHeaders.add("Cookie", "JSESSIONID=1234567890");
-        String newBody = "userId=javajigi&password=test";
-        HttpRequest newRequest = new HttpRequest(newRequestLine, newHeaders, newBody);
-        SessionResolver.injectSession(newRequest);
-        ResolveResponse<?> response = Handler.getInstance().login(newRequest, newRequest.getSession());
+        HttpRequest request = RequestBuilder.post("/login")
+                .header("Cookie", "JSESSIONID=1234567890")
+                .body("userId=javajigi&password=test")
+                .build();
+        SessionResolver.injectSession(request);
+        ResolveResponse<?> response = Handler.getInstance().login(request, request.getSession());
 
         // then
         assertThat(response.getStatusCode()).isEqualTo(HttpStatusCode.FOUND);
@@ -109,22 +102,18 @@ class HandlerTest {
     @DisplayName("로그인 요청시 잘못된 비밀번호로 요청하면 BAD_REQUEST 응답을 받는다")
     void 로그인_잘못된_비밀번호_예외_테스트() {
         // given
-        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
-        HttpHeaders headers = new HttpHeaders();
-        String body = "userId=javajigi&name=자바지기&password=test&email=javajigi%40slipp.net";
-        HttpRequest request = new HttpRequest(requestLine, headers, body);
-        Handler.getInstance().createUser(request);
+        User user = new User("javajigi", "test", "자바지기", "javajigi@naver.com");
+        Database.addUser(user);
 
         // when
-        RequestLine newRequestLine = new RequestLine("POST /login HTTP/1.1");
-        HttpHeaders newHeaders = new HttpHeaders();
-        newHeaders.add("Cookie", "JSESSIONID=1234567890");
-        String newBody = "userId=javajigi&password=wrongPassword";
-        HttpRequest newRequest = new HttpRequest(newRequestLine, newHeaders, newBody);
-        SessionResolver.injectSession(newRequest);
+        HttpRequest request = RequestBuilder.post("/login")
+                .header("Cookie", "JSESSIONID=1234567890")
+                .body("userId=javajigi&password=wrongPassword")
+                .build();
+        SessionResolver.injectSession(request);
 
         // then
-        assertThatThrownBy(() -> Handler.getInstance().login(newRequest, newRequest.getSession()))
+        assertThatThrownBy(() -> Handler.getInstance().login(request, request.getSession()))
                 .isInstanceOf(HttpException.class)
                 .hasMessageContaining("400 Bad Request");
     }
@@ -133,22 +122,18 @@ class HandlerTest {
     @DisplayName("로그인 요청시 잘못된 아이디로 요청하면 BAD_REQUEST 응답을 받는다")
     void 로그인_잘못된_아이디_예외_테스트() {
         // given
-        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
-        HttpHeaders headers = new HttpHeaders();
-        String body = "userId=javajigi&name=자바지기&password=test&email=javajigi%40slipp.net";
-        HttpRequest request = new HttpRequest(requestLine, headers, body);
-        Handler.getInstance().createUser(request);
+        User user = new User("javajigi", "test", "자바지기", "javajigi@naver.com");
+        Database.addUser(user);
 
         // when
-        RequestLine newRequestLine = new RequestLine("POST /login HTTP/1.1");
-        HttpHeaders newHeaders = new HttpHeaders();
-        newHeaders.add("Cookie", "JSESSIONID=1234567890");
-        String newBody = "userId=wrongUserId&password=test";
-        HttpRequest newRequest = new HttpRequest(newRequestLine, newHeaders, newBody);
-        SessionResolver.injectSession(newRequest);
+        HttpRequest request = RequestBuilder.post("/login")
+                .header("Cookie", "JSESSIONID=1234567890")
+                .body("userId=wrongUserId&password=test")
+                .build();
+        SessionResolver.injectSession(request);
 
         // then
-        assertThatThrownBy(() -> Handler.getInstance().login(newRequest, newRequest.getSession()))
+        assertThatThrownBy(() -> Handler.getInstance().login(request, request.getSession()))
                 .isInstanceOf(HttpException.class)
                 .hasMessageContaining("400 Bad Request");
     }

--- a/src/test/java/provider/RequestBuilder.java
+++ b/src/test/java/provider/RequestBuilder.java
@@ -1,0 +1,58 @@
+package provider;
+
+import webserver.http.common.HttpHeaders;
+import webserver.http.common.HttpMethod;
+import webserver.http.request.HttpRequest;
+import webserver.http.request.RequestLine;
+
+import static webserver.http.common.HttpConstants.SPACE;
+
+public class RequestBuilder {
+
+    private HttpMethod method = HttpMethod.GET;
+    private String path = "/";
+    private String query = "";
+    private String httpVer = "HTTP/1.1";
+    private final HttpHeaders headers = new HttpHeaders();
+    private String body = "";
+
+    public static RequestBuilder get(String path) {
+        return new RequestBuilder().method(HttpMethod.GET).path(path);
+    }
+
+    public static RequestBuilder post(String path) {
+        return new RequestBuilder().method(HttpMethod.POST).path(path);
+    }
+
+    public RequestBuilder method(HttpMethod m) {
+        this.method = m;
+        return this;
+    }
+
+    public RequestBuilder path(String p) {
+        this.path = p;
+        return this;
+    }
+
+    public RequestBuilder query(String q) {
+        this.query = q.startsWith("?") ? q : "?" + q;
+        return this;
+    }
+
+    public RequestBuilder header(String k, String v) {
+        headers.add(k, v);
+        return this;
+    }
+
+    public RequestBuilder body(String b) {
+        this.body = b;
+        return this;
+    }
+
+    public HttpRequest build() {
+        String uri = query.isEmpty() ? path : path + query;
+        String rawLine = method + SPACE + uri + SPACE + httpVer;
+        RequestLine rl = new RequestLine(rawLine);
+        return new HttpRequest(rl, headers, body);
+    }
+}

--- a/src/test/java/webserver/DispatcherTest.java
+++ b/src/test/java/webserver/DispatcherTest.java
@@ -5,9 +5,8 @@ import model.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import webserver.http.common.HttpHeaders;
+import provider.RequestBuilder;
 import webserver.http.request.HttpRequest;
-import webserver.http.request.RequestLine;
 import webserver.http.response.HttpResponse;
 import webserver.mapper.HandlerMapper;
 import webserver.resolver.SessionResolver;
@@ -52,8 +51,8 @@ class DispatcherTest {
     @DisplayName("정적 리소스 요청에 올바른 요청시 200 OK 응답과 정적 리소스 바디를 반환한다.")
     void 올바른_정적_리소스_요청시_200_ok_와_바디를_반환_테스트() throws IOException {
         // given
-        RequestLine requestLine = new RequestLine("GET /index.html HTTP/1.1");
-        HttpRequest request = new HttpRequest(requestLine, null, null);
+
+        HttpRequest request = RequestBuilder.get("/index.html").build();
         Dispatcher dispatcher = new Dispatcher(request);
 
         // when
@@ -70,8 +69,7 @@ class DispatcherTest {
     @DisplayName("정적 리소스 요청시 없는 리소스에 대해 404 Not Found 응답을 반환한다.")
     void 없는_정적_리소스_요청시_404_not_found_응답을_반환_테스트() throws IOException {
         // given
-        RequestLine requestLine = new RequestLine("GET /nonexistent.html HTTP/1.1");
-        HttpRequest request = new HttpRequest(requestLine, null, null);
+        HttpRequest request = RequestBuilder.get("/nonexistent.html").build();
         Dispatcher dispatcher = new Dispatcher(request);
 
         // when
@@ -87,9 +85,9 @@ class DispatcherTest {
     @DisplayName("POST /create 요청시 유저가 정상적으로 생성되면 302 Found 응답을 반환한다.")
     void 유저_생성_정상_요청시_302_found_응답을_반환_테스트() throws IOException {
         // given
-        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
-        String body = "userId=javajigi&name=자바지기&password=test&email=javajigi@naver.com";
-        HttpRequest request = new HttpRequest(requestLine, null, body);
+        HttpRequest request = RequestBuilder.post("/create")
+                .body("userId=javajigi&name=자바지기&password=test&email=javajigi@naver.com")
+                .build();
         Dispatcher dispatcher = new Dispatcher(request);
 
         // when
@@ -108,9 +106,9 @@ class DispatcherTest {
         User user = new User("javajigi", "test", "자바지기", "javajigi@naver.com");
         Database.addUser(user);
 
-        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
-        String body = "userId=javajigi&name=자바지기&password=test&email=javajigi@naver.com";
-        HttpRequest request = new HttpRequest(requestLine, null, body);
+        HttpRequest request = RequestBuilder.post("/create")
+                .body("userId=javajigi&name=자바지기&password=test&email=javajigi@naver.com")
+                .build();
         Dispatcher newDispatcher = new Dispatcher(request);
 
         // when
@@ -126,9 +124,9 @@ class DispatcherTest {
     @DisplayName("POST /create 요청시 파라미터가 부족하거나 잘못된 경우 400 Bad Request 응답을 반환한다.")
     void 잘못된_생성_요청시_400_Bad_Request_반환_테스트() throws IOException {
         // given
-        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
-        String body = "userId=javajigi&password=";
-        HttpRequest request = new HttpRequest(requestLine, null, body);
+        HttpRequest request = RequestBuilder.post("/create")
+                .body("userId=javajigi&password=")
+                .build();
         Dispatcher dispatcher = new Dispatcher(request);
 
         // when
@@ -147,11 +145,10 @@ class DispatcherTest {
         User user = new User("javajigi", "test", "자바지기", "javajigi@naver.com");
         Database.addUser(user);
 
-        RequestLine requestLine = new RequestLine("POST /login HTTP/1.1");
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Cookie", "JSESSIONID=1234567890");
-        String body = "userId=javajigi&name=자바지기&password=test&email=javajigi@naver.com";
-        HttpRequest request = new HttpRequest(requestLine, headers, body);
+        HttpRequest request = RequestBuilder.post("/login")
+                .header("Cookie", "JSESSIONID=1234567890")
+                .body("userId=javajigi&password=test")
+                .build();
         Dispatcher dispatcher = new Dispatcher(request);
 
         // when
@@ -167,10 +164,9 @@ class DispatcherTest {
     @DisplayName("POST /login 요청시 유저가 존재하지 않으면 새로운 쿠키 생성 헤더가 없으며 400 Bad Request 응답을 반환한다.")
     void 존재하지_않는_유저_로그인_요청시_400_Bad_Request_반환_테스트() throws IOException {
         // given
-        RequestLine requestLine = new RequestLine("POST /login HTTP/1.1");
-        HttpHeaders headers = new HttpHeaders();
-        String body = "userId=nonexistent&password=test";
-        HttpRequest request = new HttpRequest(requestLine, headers, body);
+        HttpRequest request = RequestBuilder.post("/login")
+                .body("userId=nonexistent&password=test")
+                .build();
         Dispatcher dispatcher = new Dispatcher(request);
 
         // when
@@ -190,10 +186,9 @@ class DispatcherTest {
         User user = new User("javajigi", "test", "자바지기", "javajigi@naver.com");
         Database.addUser(user);
 
-        RequestLine requestLine = new RequestLine("POST /login HTTP/1.1");
-        HttpHeaders headers = new HttpHeaders();
-        String body = "userId=javajigi&password=";
-        HttpRequest request = new HttpRequest(requestLine, headers, body);
+        HttpRequest request = RequestBuilder.post("/login")
+                .body("userId=javajigi&password=")
+                .build();
         Dispatcher dispatcher = new Dispatcher(request);
 
         // when
@@ -214,19 +209,18 @@ class DispatcherTest {
         Database.addUser(user);
 
         // when
-        RequestLine newRequestLine = new RequestLine("POST /login HTTP/1.1");
-        String newBody = "userId=javajigi&password=test";
-        HttpHeaders newHeaders = new HttpHeaders();
-        HttpRequest newRequest = new HttpRequest(newRequestLine, newHeaders, newBody);
-        SessionResolver.injectSession(newRequest);
-        Dispatcher newDispatcher = new Dispatcher(newRequest);
+        HttpRequest request = RequestBuilder.post("/login")
+                .body("userId=javajigi&password=test")
+                .build();
+        SessionResolver.injectSession(request);
+        Dispatcher newDispatcher = new Dispatcher(request);
 
         HttpResponse dispatchResult = newDispatcher.dispatch();
         String response = new String(dispatchResult.getBytes(), StandardCharsets.UTF_8);
 
         // then
-        assertThat(newRequest.getSession()).isNotNull();
-        assertThat(newRequest.getSession().getAttribute("user")).isNotNull();
+        assertThat(request.getSession()).isNotNull();
+        assertThat(request.getSession().getAttribute("user")).isNotNull();
         assertThat(response).contains("Set-Cookie: JSESSIONID=");
     }
 

--- a/src/test/java/webserver/DispatcherTest.java
+++ b/src/test/java/webserver/DispatcherTest.java
@@ -1,0 +1,229 @@
+package webserver;
+
+import db.Database;
+import model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import webserver.http.common.HttpHeaders;
+import webserver.http.request.HttpRequest;
+import webserver.http.request.RequestLine;
+import webserver.http.response.HttpResponse;
+import webserver.resolver.SessionResolver;
+import webserver.session.SessionManager;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DispatcherTest {
+
+    @BeforeEach
+    void setUp() {
+        // db 초기화 리플렉션
+        try {
+            Field usersField = Database.class.getDeclaredField("users");
+            usersField.setAccessible(true);
+            Map<?, ?> usersMap = (Map<?, ?>) usersField.get(null);
+            usersMap.clear();
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+
+        // 세션 초기화
+        try {
+            Field sessionManagerField = SessionManager.class.getDeclaredField("sessions");
+            sessionManagerField.setAccessible(true);
+            Map<?, ?> sessionManagerMap = (Map<?, ?>) sessionManagerField.get(null);
+            sessionManagerMap.clear();
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    @DisplayName("정적 리소스 요청에 올바른 요청시 200 OK 응답과 정적 리소스 바디를 반환한다.")
+    void 올바른_정적_리소스_요청시_200_ok_와_바디를_반환_테스트() throws IOException {
+        // given
+        RequestLine requestLine = new RequestLine("GET /index.html HTTP/1.1");
+        HttpRequest request = new HttpRequest(requestLine, null, null);
+        Dispatcher dispatcher = new Dispatcher(request);
+
+        // when
+        HttpResponse dispatchResult = dispatcher.dispatch();
+        String response = new String(dispatchResult.getBytes(), StandardCharsets.UTF_8);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response).contains("200 OK");
+        assertThat(response).contains("<html>");
+    }
+
+    @Test
+    @DisplayName("정적 리소스 요청시 없는 리소스에 대해 404 Not Found 응답을 반환한다.")
+    void 없는_정적_리소스_요청시_404_not_found_응답을_반환_테스트() throws IOException {
+        // given
+        RequestLine requestLine = new RequestLine("GET /nonexistent.html HTTP/1.1");
+        HttpRequest request = new HttpRequest(requestLine, null, null);
+        Dispatcher dispatcher = new Dispatcher(request);
+
+        // when
+        HttpResponse dispatchResult = dispatcher.dispatch();
+        String response = new String(dispatchResult.getBytes(), StandardCharsets.UTF_8);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response).contains("404 Not Found");
+    }
+
+    @Test
+    @DisplayName("POST /create 요청시 유저가 정상적으로 생성되면 302 Found 응답을 반환한다.")
+    void 유저_생성_정상_요청시_302_found_응답을_반환_테스트() throws IOException {
+        // given
+        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
+        String body = "userId=javajigi&name=자바지기&password=test&email=javajigi@naver.com";
+        HttpRequest request = new HttpRequest(requestLine, null, body);
+        Dispatcher dispatcher = new Dispatcher(request);
+
+        // when
+        HttpResponse dispatchResult = dispatcher.dispatch();
+        String response = new String(dispatchResult.getBytes(), StandardCharsets.UTF_8);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response).contains("302 Found");
+    }
+
+    @Test
+    @DisplayName("POST /create 요청시 유저가 이미 존재하면 409 Conflict 응답을 반환한다.")
+    void 중복된_유저_생성_요청시_409_Conflict_반환_테스트() throws IOException {
+        // given
+        User user = new User("javajigi", "test", "자바지기", "javajigi@naver.com");
+        Database.addUser(user);
+
+        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
+        String body = "userId=javajigi&name=자바지기&password=test&email=javajigi@naver.com";
+        HttpRequest request = new HttpRequest(requestLine, null, body);
+        Dispatcher newDispatcher = new Dispatcher(request);
+
+        // when
+        HttpResponse dispatchResult = newDispatcher.dispatch();
+        String response = new String(dispatchResult.getBytes(), StandardCharsets.UTF_8);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response).contains("409 Conflict");
+    }
+
+    @Test
+    @DisplayName("POST /create 요청시 파라미터가 부족하거나 잘못된 경우 400 Bad Request 응답을 반환한다.")
+    void 잘못된_생성_요청시_400_Bad_Request_반환_테스트() throws IOException {
+        // given
+        RequestLine requestLine = new RequestLine("POST /create HTTP/1.1");
+        String body = "userId=javajigi&password=";
+        HttpRequest request = new HttpRequest(requestLine, null, body);
+        Dispatcher dispatcher = new Dispatcher(request);
+
+        // when
+        HttpResponse dispatchResult = dispatcher.dispatch();
+        String response = new String(dispatchResult.getBytes(), StandardCharsets.UTF_8);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response).contains("400 Bad Request");
+    }
+
+    @Test
+    @DisplayName("POST /login 요청시 유저가 정상적으로 로그인되면 302 Found 응답을 반환한다.")
+    void 유저_로그인_정상_요청시_302_found_응답을_반환_테스트() throws IOException {
+        // given
+        User user = new User("javajigi", "test", "자바지기", "javajigi@naver.com");
+        Database.addUser(user);
+
+        RequestLine requestLine = new RequestLine("POST /login HTTP/1.1");
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Cookie", "JSESSIONID=1234567890");
+        String body = "userId=javajigi&name=자바지기&password=test&email=javajigi@naver.com";
+        HttpRequest request = new HttpRequest(requestLine, headers, body);
+        Dispatcher dispatcher = new Dispatcher(request);
+
+        // when
+        HttpResponse dispatchResult = dispatcher.dispatch();
+        String response = new String(dispatchResult.getBytes(), StandardCharsets.UTF_8);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response).contains("302 Found");
+    }
+
+    @Test
+    @DisplayName("POST /login 요청시 유저가 존재하지 않으면 새로운 쿠키 생성 헤더가 없으며 400 Bad Request 응답을 반환한다.")
+    void 존재하지_않는_유저_로그인_요청시_400_Bad_Request_반환_테스트() throws IOException {
+        // given
+        RequestLine requestLine = new RequestLine("POST /login HTTP/1.1");
+        HttpHeaders headers = new HttpHeaders();
+        String body = "userId=nonexistent&password=test";
+        HttpRequest request = new HttpRequest(requestLine, headers, body);
+        Dispatcher dispatcher = new Dispatcher(request);
+
+        // when
+        HttpResponse dispatchResult = dispatcher.dispatch();
+        String response = new String(dispatchResult.getBytes(), StandardCharsets.UTF_8);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response).contains("400 Bad Request");
+        assertThat(response).doesNotContain("Set-Cookie");
+    }
+
+    @Test
+    @DisplayName("POST /login 요청시 파라미터가 부족하거나 잘못된 경우 새로운 쿠키 생성 헤더가 없으며 400 Bad Request 응답을 반환한다.")
+    void 잘못된_로그인_요청시_400_Bad_Request_반환_테스트() throws IOException {
+        // given
+        User user = new User("javajigi", "test", "자바지기", "javajigi@naver.com");
+        Database.addUser(user);
+
+        RequestLine requestLine = new RequestLine("POST /login HTTP/1.1");
+        HttpHeaders headers = new HttpHeaders();
+        String body = "userId=javajigi&password=";
+        HttpRequest request = new HttpRequest(requestLine, headers, body);
+        Dispatcher dispatcher = new Dispatcher(request);
+
+        // when
+        HttpResponse dispatchResult = dispatcher.dispatch();
+        String response = new String(dispatchResult.getBytes(), StandardCharsets.UTF_8);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response).contains("400 Bad Request");
+        assertThat(response).doesNotContain("Set-Cookie");
+    }
+
+    @Test
+    @DisplayName("POST /login 요청시 정상 로그인 후 세션에 유저 정보가 담기며 Set Cookie 헤더가 포함된다.")
+    void 정상_로그인_요청시_쿠키_및_세션_정상_주입_테스트() throws IOException {
+        // given
+        User user = new User("javajigi", "test", "자바지기", "javajigi@naver.com");
+        Database.addUser(user);
+
+        // when
+        RequestLine newRequestLine = new RequestLine("POST /login HTTP/1.1");
+        String newBody = "userId=javajigi&password=test";
+        HttpHeaders newHeaders = new HttpHeaders();
+        HttpRequest newRequest = new HttpRequest(newRequestLine, newHeaders, newBody);
+        SessionResolver.injectSession(newRequest);
+        Dispatcher newDispatcher = new Dispatcher(newRequest);
+
+        HttpResponse dispatchResult = newDispatcher.dispatch();
+        String response = new String(dispatchResult.getBytes(), StandardCharsets.UTF_8);
+
+        // then
+        assertThat(newRequest.getSession()).isNotNull();
+        assertThat(newRequest.getSession().getAttribute("user")).isNotNull();
+        assertThat(response).contains("Set-Cookie: JSESSIONID=");
+    }
+
+}

--- a/src/test/java/webserver/DispatcherTest.java
+++ b/src/test/java/webserver/DispatcherTest.java
@@ -9,6 +9,7 @@ import webserver.http.common.HttpHeaders;
 import webserver.http.request.HttpRequest;
 import webserver.http.request.RequestLine;
 import webserver.http.response.HttpResponse;
+import webserver.mapper.HandlerMapper;
 import webserver.resolver.SessionResolver;
 import webserver.session.SessionManager;
 
@@ -42,6 +43,9 @@ class DispatcherTest {
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }
+
+        // HandlerMapper 초기화
+        HandlerMapper.getInstance().initialize();
     }
 
     @Test

--- a/src/test/java/webserver/http/common/CookieShopTest.java
+++ b/src/test/java/webserver/http/common/CookieShopTest.java
@@ -1,0 +1,50 @@
+package webserver.http.common;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CookieShopTest {
+
+    @Test
+    @DisplayName("HttpHeaders에서 세션 아이디를 가져온다")
+    void 헤더_세션_추출_테스트() {
+        // given
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Cookie", "JSESSIONID=1234567890");
+
+        // when
+        String sessionId = CookieShop.takeSessionIdFrom(headers);
+
+        // then
+        assertThat(sessionId).isEqualTo("1234567890");
+    }
+
+    @Test
+    @DisplayName("HttpHeaders에서 쿠키값이 없으면 null을 반환한다")
+    void 헤더_쿠키_없음_테스트() {
+        // given
+        HttpHeaders headers = new HttpHeaders();
+
+        // when
+        String sessionId = CookieShop.takeSessionIdFrom(headers);
+
+        // then
+        assertThat(sessionId).isNull();
+    }
+
+    @Test
+    @DisplayName("sessionId를 주면 쿠키 Field 를 반환한다")
+    void 쿠키_Field_파싱_테스트() {
+        // given
+        String sessionId = "1234567890";
+
+        // when
+        String cookie = CookieShop.bakeSessionCookie(sessionId);
+
+        // then
+        assertThat(cookie).isEqualTo("JSESSIONID=1234567890;Path=/;HttpOnly");
+    }
+
+}

--- a/src/test/java/webserver/resolver/ResourceResolverTest.java
+++ b/src/test/java/webserver/resolver/ResourceResolverTest.java
@@ -2,10 +2,9 @@ package webserver.resolver;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import webserver.http.common.HttpHeaders;
+import provider.RequestBuilder;
 import webserver.http.exception.HttpException;
 import webserver.http.request.HttpRequest;
-import webserver.http.request.RequestLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -16,9 +15,7 @@ class ResourceResolverTest {
     @DisplayName("존재하는 리소스 요청이 주어졌을 때, 200 OK 응답과 파일 내용이 전송되어야 한다.")
     void 올바른_리소스_요청_200_응답_반환_테스트() {
         // Given
-        RequestLine requestLine = new RequestLine("GET /index.html HTTP/1.1");
-        HttpHeaders headers = new HttpHeaders();
-        HttpRequest request = new HttpRequest(requestLine, headers, "");
+        HttpRequest request = RequestBuilder.get("/index.html").build();
         ResourceResolver resolver = new ResourceResolver(request);
 
         // When
@@ -34,9 +31,7 @@ class ResourceResolverTest {
     @DisplayName("존재하지 않는 리소스 요청이 주어졌을 때, 404 Not Found 예외가 발생해야 한다.")
     void 존재하지_않은_리소스_404응답_반환_테스트() {
         // Given
-        RequestLine requestLine = new RequestLine("GET /nonexistent.txt HTTP/1.1");
-        HttpHeaders headers = new HttpHeaders();
-        HttpRequest request = new HttpRequest(requestLine, headers, "");
+        HttpRequest request = RequestBuilder.get("/nonexistent.txt").build();
         ResourceResolver resolver = new ResourceResolver(request);
 
         // When & Then
@@ -49,9 +44,7 @@ class ResourceResolverTest {
     @DisplayName("디렉토리 요청이 주어졌을 때, 해당 디렉토리 내의 index.html 파일을 반환해야 한다.")
     void 디렉토리_요청_테스트() {
         // Given
-        RequestLine requestLine = new RequestLine("GET /registration HTTP/1.1");
-        HttpHeaders headers = new HttpHeaders();
-        HttpRequest request = new HttpRequest(requestLine, headers, "");
+        HttpRequest request = RequestBuilder.get("/registration/index.html").build();
         ResourceResolver resolver = new ResourceResolver(request);
 
         // When
@@ -67,9 +60,7 @@ class ResourceResolverTest {
     @DisplayName("디렉토리 요청이 주어졌을 때, 해당 디렉토리가 존재하지 않으면 404 Not Found 예외가 발생해야 한다.")
     void 존재하지_않는_디렉토리_요청_404응답_반환_테스트() {
         // Given
-        RequestLine requestLine = new RequestLine("GET /nonexistent_directory HTTP/1.1");
-        HttpHeaders headers = new HttpHeaders();
-        HttpRequest request = new HttpRequest(requestLine, headers, "");
+        HttpRequest request = RequestBuilder.get("/nonexistent_directory/index.html").build();
         ResourceResolver resolver = new ResourceResolver(request);
 
         // When & Then

--- a/src/test/java/webserver/resolver/SessionResolverTest.java
+++ b/src/test/java/webserver/resolver/SessionResolverTest.java
@@ -2,9 +2,8 @@ package webserver.resolver;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import webserver.http.common.HttpHeaders;
+import provider.RequestBuilder;
 import webserver.http.request.HttpRequest;
-import webserver.http.request.RequestLine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,10 +13,9 @@ class SessionResolverTest {
     @DisplayName("HttpRequest Headers에 세션이 존재하면 세션을 주입한다")
     void 세션_존재시_주입_테스트() {
         // given
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Cookie", "JSESSIONID=1234567890");
-        RequestLine requestLine = new RequestLine("GET / HTTP/1.1");
-        HttpRequest request = new HttpRequest(requestLine, headers, null);
+        HttpRequest request = RequestBuilder.get("/")
+                .header("Cookie", "JSESSIONID=1234567890")
+                .build();
 
         // when
         SessionResolver.injectSession(request);
@@ -30,9 +28,7 @@ class SessionResolverTest {
     @DisplayName("HttpRequest Headers에 세션이 존재하지 않으면 새로운 세션을 생성한다")
     void 세션_부재시_생성_테스트() {
         // given
-        HttpHeaders headers = new HttpHeaders();
-        RequestLine requestLine = new RequestLine("GET / HTTP/1.1");
-        HttpRequest request = new HttpRequest(requestLine, headers, null);
+        HttpRequest request = RequestBuilder.get("/").build();
 
         // when
         SessionResolver.injectSession(request);
@@ -45,9 +41,7 @@ class SessionResolverTest {
     @DisplayName("HttpRequest에 새로운 세션이 생성되면 새로운 쿠키 추가 헤더를 추가한다")
     void 새로운_세션_쿠키_추가_테스트() {
         // given
-        HttpHeaders headers = new HttpHeaders();
-        RequestLine requestLine = new RequestLine("GET / HTTP/1.1");
-        HttpRequest request = new HttpRequest(requestLine, headers, null);
+        HttpRequest request = RequestBuilder.get("/").build();
         SessionResolver.injectSession(request);
 
         // when
@@ -62,10 +56,9 @@ class SessionResolverTest {
     @DisplayName("HttpRequest에 새로운 세션이 없으면 쿠키 추가 헤더를 추가하지 않는다")
     void 세션_이미_존재시_헤더에_추가_안함_테스트() {
         // given
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Cookie", "JSESSIONID=1234567890");
-        RequestLine requestLine = new RequestLine("GET / HTTP/1.1");
-        HttpRequest request = new HttpRequest(requestLine, headers, null);
+        HttpRequest request = RequestBuilder.get("/")
+                .header("Cookie", "JSESSIONID=1234567890")
+                .build();
         SessionResolver.injectSession(request);
 
         // when

--- a/src/test/java/webserver/resolver/SessionResolverTest.java
+++ b/src/test/java/webserver/resolver/SessionResolverTest.java
@@ -1,0 +1,79 @@
+package webserver.resolver;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import webserver.http.common.HttpHeaders;
+import webserver.http.request.HttpRequest;
+import webserver.http.request.RequestLine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SessionResolverTest {
+
+    @Test
+    @DisplayName("HttpRequest Headers에 세션이 존재하면 세션을 주입한다")
+    void 세션_존재시_주입_테스트() {
+        // given
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Cookie", "JSESSIONID=1234567890");
+        RequestLine requestLine = new RequestLine("GET / HTTP/1.1");
+        HttpRequest request = new HttpRequest(requestLine, headers, null);
+
+        // when
+        SessionResolver.injectSession(request);
+
+        // then
+        assertThat(request.getSessionId()).isEqualTo("1234567890");
+    }
+
+    @Test
+    @DisplayName("HttpRequest Headers에 세션이 존재하지 않으면 새로운 세션을 생성한다")
+    void 세션_부재시_생성_테스트() {
+        // given
+        HttpHeaders headers = new HttpHeaders();
+        RequestLine requestLine = new RequestLine("GET / HTTP/1.1");
+        HttpRequest request = new HttpRequest(requestLine, headers, null);
+
+        // when
+        SessionResolver.injectSession(request);
+
+        // then
+        assertThat(request.getSessionId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("HttpRequest에 새로운 세션이 생성되면 새로운 쿠키 추가 헤더를 추가한다")
+    void 새로운_세션_쿠키_추가_테스트() {
+        // given
+        HttpHeaders headers = new HttpHeaders();
+        RequestLine requestLine = new RequestLine("GET / HTTP/1.1");
+        HttpRequest request = new HttpRequest(requestLine, headers, null);
+        SessionResolver.injectSession(request);
+
+        // when
+        ResolveResponse<?> response = ResolveResponse.ok("Hello World");
+        SessionResolver.addSessionCookieIfNew(request, response);
+
+        // then
+        assertThat(response.getHeaders().get("Set-Cookie")).isNotNull();
+    }
+
+    @Test
+    @DisplayName("HttpRequest에 새로운 세션이 없으면 쿠키 추가 헤더를 추가하지 않는다")
+    void 세션_이미_존재시_헤더에_추가_안함_테스트() {
+        // given
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Cookie", "JSESSIONID=1234567890");
+        RequestLine requestLine = new RequestLine("GET / HTTP/1.1");
+        HttpRequest request = new HttpRequest(requestLine, headers, null);
+        SessionResolver.injectSession(request);
+
+        // when
+        ResolveResponse<?> response = ResolveResponse.ok("Hello World");
+        SessionResolver.addSessionCookieIfNew(request, response);
+
+        // then
+        assertThat(response.getHeaders().get("Set-Cookie")).isNull();
+    }
+
+}


### PR DESCRIPTION
## 구현 내용

- **세션 & 쿠키 기반 로그인 흐름 도입**
    - SessionManager
        - `getOrCreateSession(String id) `: 쿠키에 JSESSIONID 가 없거나 만료되었을 때만 HttpSession 생성합니다
        - HttpRequest 객체에서 `isNewSession` 플래그를 보유해 “한 번만 Set‑Cookie” 발급합니다
    - CookieShop
        - `takeSessionIdFrom(HttpHeaders)` 로 쿠키 파싱합니다
        - `bakeSessionCookie(String id)` 로 `Set‑Cookie: JSESSIONID=…; Path=/; HttpOnly `생성합니다
    - SessionResolver
        - 세션 생성 및 쿠키 삽입을 SessionResolver 에 위임해서 필요한 작업을 추상화시켰습니다.
- **Dispatcher**
    - 응답 직전 addSessionCookieIfNew() 실행 → 새 세션일 때만 헤더에 쿠키를 추가합니다
- **HandlerMapper**
    - 파라미터 자동 주입: HttpRequest, HttpSession 두 타입만 지원하게 했습니다
    - 등록 시점에 시그니처 검증 → 지원하지 않는 타입 포함 시 앱이 즉시 실패(Fail‑Fast).
    - 파라미터에 HttpSession 이 있어야 새로운session 이 주입됩니다
- **Handler**
    - login(HttpRequest, HttpSession) : 세션 주입 받아 `session.setAttribute("user", …)` 이용해 실제 스프링처럼 attribute 를 저장합니다
    - 회원가입·로그인 성공 시 `ResolveResponse.redirect("/")`
- **유틸 개선**
    - HttpRequest 에서 세션 로직 제거 → 순수 HTTP 데이터 전용.
    - 모든 세션 생명주기를 SessionManager 한 곳으로 집중.

## 고민 사항

- 현재 Handler 내에 메소드에 매개변수로 HttpSession 이 있으면 일단 HttpRequest에서 생성하거나 받아오게 되어있다보니 HttpSession을 사용하지 않아도 매개변수에 있기만 하면 생성후 쿠키에 담아서 보내는 현상이 있습니다. 실제로 attribute를 사용한다던지를 했을 때 session 을 등록해주고싶지만 여러가지 플래그들과 분기들 때문에 망설여져서 우선은 보류하는 쪽으로 선택했습니다.

- HandlerMapper 클래스가 로딩이될 때 Handler의 메소드를 `Map<>`에 저장하게 되다보니 첫 요청이 들어와서 Dispatcher를 거쳐야만 HandlerMapper가 로딩이 되어야했습니다. 그러다보니 항상 첫 요청에 대한 Latency 가 80ms까지 나오게 됐었습니다. 어떻게 줄일 수 있을까 고민을 한 결과 `accept()` 로 요청을 기다리기 전에 미리 로딩을 시켜놓는 방법을 선택했습니다. 사전로딩 방식을 채택후 40ms까지 줄어들었지만 실행도 리플렉션이기 때문에 Handler에 각 메소드들의 첫 요청도 Latency가 좀 크게 나오고 있습니다. 이 부분도 개선이 필요할 것 같습니다.

## 기타